### PR TITLE
Change to expression templates for initializing operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ ELSE()
 ENDIF()
 
 # we crave 'modern' C++
-SET (CMAKE_CXX_STANDARD 11)
+SET (CMAKE_CXX_STANDARD 14)
 
 # add our include directory to search path
 INCLUDE_DIRECTORIES(include/)

--- a/examples/wave-equation.cc
+++ b/examples/wave-equation.cc
@@ -39,8 +39,8 @@ int main(int argc, char *argv[])
     constexpr stenseal::Stencil<2> left_boundary((-1.0)*usym[0] + 1.0*usym[1]);
     constexpr stenseal::Stencil<2> right_boundary((-1.0)*usym[-1] + 1.0*usym[0]);
 
-    constexpr stenseal::BlockStencil<2,1> left_boundary_block(left_boundary);
-    constexpr stenseal::BlockStencil<2,1> right_boundary_block(right_boundary);
+    constexpr stenseal::StencilArray<2,1> left_boundary_block(left_boundary);
+    constexpr stenseal::StencilArray<2,1> right_boundary_block(right_boundary);
     constexpr OperatorType Dm(interior, left_boundary_block, right_boundary_block);
   }
 

--- a/include/stenseal/block_operator.h
+++ b/include/stenseal/block_operator.h
@@ -12,25 +12,26 @@
 namespace stenseal
 {
 
-  template <int dim, typename StencilDm, typename StencilDp, typename Geometry>
+  template <int dim, typename DmT, typename Geometry>
   class UpwindBlockOperator
   {
   private:
-    Geometry geometry;
+    const DmT Dm;
+    const Geometry geometry;
 
     unsigned int n_nodes_tot;
 
   public:
-    UpwindBlockOperator(const Geometry &g);
+    UpwindBlockOperator(const DmT dm, const Geometry &g);
 
     void apply(dealii::Vector<double> &dst, const dealii::Vector<double> &src) const;
 
   };
 
-  template <int dim, typename StencilDm, typename StencilDp, typename Geometry>
-  UpwindBlockOperator<dim,StencilDm,StencilDp,Geometry>
-  ::UpwindBlockOperator(const Geometry &g)
-    : geometry(g)
+  template <int dim, typename DmT, typename Geometry>
+  UpwindBlockOperator<dim,DmT,Geometry>
+  ::UpwindBlockOperator(const DmT dm, const Geometry &g)
+    : Dm(dm), geometry(g)
   {
     n_nodes_tot = 1;
     for(int d = 0; d < dim; ++d) {
@@ -39,8 +40,8 @@ namespace stenseal
   }
 
 
-  template <int dim, typename StencilDm, typename StencilDp, typename Geometry>
-  void UpwindBlockOperator<dim,StencilDm,StencilDp,Geometry>
+  template <int dim, typename DmT, typename Geometry>
+  void UpwindBlockOperator<dim,DmT,Geometry>
   ::apply(dealii::Vector<double> &dst,
           const dealii::Vector<double> &src) const
   {
@@ -57,100 +58,25 @@ namespace stenseal
       const unsigned int n = geometry.n_nodes[0];
 
       // for now, use full temporary array
-      // FIXME: this is stupid!!
+      // FIXME: this is stupid!! instead use blocking
       dealii::Vector<double> tmp (n_nodes_tot);
 
       //-------------------------------------------------------------------------
       // apply Dm
       //-------------------------------------------------------------------------
 
-      // left boundary
-      for(int i = 0;
-          i < StencilDm::boundary_height;
-          ++i) {
+      Dm.apply(tmp,src,n);
 
-        double t = 0;
-        for(int j = 0; j < StencilDm::boundary_width; ++j)
-          t += src[0+j]*StencilDm::boundary_stencil[i*StencilDm::boundary_width + j];
-
-        tmp[i] = geometry.get_c(i)*t;
+      // stupid inefficient way of multiplying with c and 1/h^2
+      // FIXME: merge with above.
+      for(int i = 0; i<n; ++i) {
+        tmp[i] *= geometry.get_c(i);
       }
-
-      // interior
-      for(int i = StencilDm::boundary_height;
-          i < (n - StencilDm::boundary_height) ;
-          ++i) {
-
-        double t = 0;
-        for(int j = 0;
-            j < StencilDm::interior_width;
-            ++j)
-          t += src[i+StencilDm::interior_start_idx+j]*StencilDm::interior_stencil[j];
-
-        tmp[i] = geometry.get_c(i)*t;
-
-      }
-
-      // right boundary
-      for(int i = 0;
-          i < StencilDm::boundary_height;
-          ++i) {
-
-        double t = 0;
-        for(int j = 0; j < StencilDm::boundary_width; ++j)
-
-          t += src[n - StencilDm::boundary_width+j] * (-1) * StencilDm::boundary_stencil[(StencilDm::boundary_height-1 - i)*StencilDm::boundary_width
-                                                                                         + (StencilDm::boundary_width-1 - j)];
-
-        tmp[n - StencilDm::boundary_height + i] = geometry.get_c(n - StencilDm::boundary_height + i)*t;
-      }
-
 
       //-------------------------------------------------------------------------
       // apply Dp
       //-------------------------------------------------------------------------
-
-      // left boundary
-      for(int i = 0;
-          i < StencilDp::boundary_height;
-          ++i) {
-
-        double t = 0;
-        for(int j = 0; j < StencilDp::boundary_width; ++j)
-          t += tmp[0+j]*StencilDp::boundary_stencil[i*StencilDp::boundary_width + j];
-
-        dst[i] = t;
-      }
-
-      // interior
-      for(int i = StencilDp::boundary_height;
-          i < (n - StencilDp::boundary_height) ;
-          ++i) {
-
-        double t = 0;
-        for(int j = 0;
-            j < StencilDp::interior_width;
-            ++j)
-          t += tmp[i+StencilDp::interior_start_idx+j]*StencilDp::interior_stencil[j];
-
-        dst[i] = t;
-
-      }
-
-      // right boundary
-      for(int i = 0;
-          i < StencilDp::boundary_height;
-          ++i) {
-
-        double t = 0;
-        for(int j = 0; j < StencilDp::boundary_width; ++j)
-
-          t += tmp[n - StencilDp::boundary_width+j] * (-1) * StencilDp::boundary_stencil[(StencilDp::boundary_height-1 - i)*StencilDp::boundary_width
-                                                                                         + (StencilDp::boundary_width-1 - j)];
-
-        dst[n - StencilDp::boundary_height + i] = t;
-      }
-
+      Dm.apply_dp(dst,tmp,n);
 
 
     }

--- a/include/stenseal/block_operator.h
+++ b/include/stenseal/block_operator.h
@@ -12,21 +12,37 @@
 namespace stenseal
 {
 
+  /**
+   * Class representing a Upwind Laplace operator defined by the 1D 1st
+   * derivative "D-minus" operator DmT, on a `dim` dimensional grid block with
+   * geometry defined by the type `Geometry`.
+   */
   template <int dim, typename DmT, typename Geometry>
   class UpwindBlockOperator
   {
   private:
     const DmT Dm;
     const Geometry geometry;
-
     unsigned int n_nodes_tot;
 
   public:
+  /**
+   * Constructor. Takes the 1D D-minus Upwind SBP operator `dm`, and the
+   * geometry descriptor `g` of this grid block.
+   */
     UpwindBlockOperator(const DmT dm, const Geometry &g);
 
+  /**
+   * Apply this operator to the vector `src` writing the result into `dst`.
+   */
     void apply(dealii::Vector<double> &dst, const dealii::Vector<double> &src) const;
-
   };
+
+
+
+  //---------------------------------------------------------------------------
+  // implementations
+  //---------------------------------------------------------------------------
 
   template <int dim, typename DmT, typename Geometry>
   UpwindBlockOperator<dim,DmT,Geometry>

--- a/include/stenseal/block_stencil.h
+++ b/include/stenseal/block_stencil.h
@@ -16,7 +16,7 @@ namespace stenseal
    * wide.
    */
   template <int width, int height>
-  class BlockStencil
+  class StencilArray
   {
   private:
     const std::array<Stencil<width>,height> stencils;
@@ -28,7 +28,7 @@ namespace stenseal
      * input.
      */
     template <typename... Ss>
-    constexpr  BlockStencil(const Ss... s);
+    constexpr  StencilArray(const Ss... s);
 
     /**
      * Access a specific row of the block.
@@ -43,14 +43,14 @@ namespace stenseal
 
   template <int width, int height>
   template <typename... Ss>
-  constexpr BlockStencil<width,height>::BlockStencil(const Ss... s)
+  constexpr StencilArray<width,height>::StencilArray(const Ss... s)
     : stencils{s...}
   {
     static_assert(sizeof...(Ss) == height, "wrong number of arguments");
   }
 
   template <int width, int height>
-  inline constexpr const Stencil<width>& BlockStencil<width,height>::operator[](int row) const {
+  inline constexpr const Stencil<width>& StencilArray<width,height>::operator[](int row) const {
     return stencils[row];
   }
 

--- a/include/stenseal/block_stencil.h
+++ b/include/stenseal/block_stencil.h
@@ -11,22 +11,49 @@
 namespace stenseal
 {
 
+  /**
+   * Class representing a block of `Stencil`s with `height` rows, each `width`
+   * wide.
+   */
   template <int width, int height>
-  struct BlockStencil
+  class BlockStencil
   {
+  private:
     const std::array<Stencil<width>,height> stencils;
 
-    template <typename... Ss>
-    constexpr  BlockStencil(const Ss... s)
-      : stencils{s...}
-    {
-      static_assert(sizeof...(Ss) == height, "wrong number of arguments");
-    }
+  public:
 
-    constexpr const Stencil<width>& operator[](int row) const {
-      return stencils[row];
-    }
+    /**
+     * Constructor. Called with a matching number of `height` `Stencil`s as
+     * input.
+     */
+    template <typename... Ss>
+    constexpr  BlockStencil(const Ss... s);
+
+    /**
+     * Access a specific row of the block.
+     */
+    inline constexpr const Stencil<width>& operator[](int row) const;
   };
+
+
+  //---------------------------------------------------------------------------
+  // Implementations
+  //---------------------------------------------------------------------------
+
+  template <int width, int height>
+  template <typename... Ss>
+  constexpr BlockStencil<width,height>::BlockStencil(const Ss... s)
+    : stencils{s...}
+  {
+    static_assert(sizeof...(Ss) == height, "wrong number of arguments");
+  }
+
+  template <int width, int height>
+  inline constexpr const Stencil<width>& BlockStencil<width,height>::operator[](int row) const {
+    return stencils[row];
+  }
+
 }
 
 #endif /* _BLOCK_STENCIL_H */

--- a/include/stenseal/block_stencil.h
+++ b/include/stenseal/block_stencil.h
@@ -1,0 +1,32 @@
+/* -*- c-basic-offset:2; tab-width:2; indent-tabs-mode:nil -*-
+ *
+ *
+ */
+
+#ifndef _BLOCK_STENCIL_H
+#define _BLOCK_STENCIL_H
+
+#include "stenseal/stencil.h"
+
+namespace stenseal
+{
+
+  template <int width, int height>
+  struct BlockStencil
+  {
+    const std::array<Stencil<width>,height> stencils;
+
+    template <typename... Ss>
+    constexpr  BlockStencil(const Ss... s)
+      : stencils{s...}
+    {
+      static_assert(sizeof...(Ss) == height, "wrong number of arguments");
+    }
+
+    constexpr const Stencil<width>& operator[](int row) const {
+      return stencils[row];
+    }
+  };
+}
+
+#endif /* _BLOCK_STENCIL_H */

--- a/include/stenseal/operator.h
+++ b/include/stenseal/operator.h
@@ -17,6 +17,12 @@
 //=============================================================================
 namespace stenseal
 {
+  /**
+   * Class representing a 1D SBP operator, width an interior stencil with width
+   * `width_interior`, and distinct boundary stencil blocks on the left and
+   * right boundary, both with `height_boundary` rows of width `width_boundary`.
+   *
+   */
   template <int width_interior,
             int width_boundary,
             int height_boundary>
@@ -26,49 +32,89 @@ namespace stenseal
     const BlockStencil<width_boundary,height_boundary> lboundary;
     const BlockStencil<width_boundary,height_boundary> rboundary;
     const Stencil<width_interior> interior;
-
   public:
+
+    /**
+     * Constructor. Takes the interior `Stencil` `i`, and the `BlockStencil`s
+     * `l` and `r` for the left and right boundaries respectively.
+     */
     constexpr Operator(const Stencil<width_interior> i,
                        const BlockStencil<width_boundary,height_boundary> l,
-                       const BlockStencil<width_boundary,height_boundary> r)
-      :interior(i), lboundary(l), rboundary(r)
-    {}
+                       const BlockStencil<width_boundary,height_boundary> r);
 
+    /**
+     * Apply this `Operator` to the vector `src` and write the result into
+     * `dst`, both of which have length `n`.
+     */
     void apply(dealii::Vector<double> &dst,
                const dealii::Vector<double> &src,
-               const unsigned int n) const
-    {
-      for(int i = 0; i < height_boundary; ++i) {
-        dst[i] = lboundary[i].apply(src,i);
-      }
-
-      for(int i = height_boundary; i < n-height_boundary; ++i) {
-        dst[i] = interior.apply(src,i);
-      }
-
-      for(int i = n-height_boundary; i < n; ++i) {
-        dst[i] = rboundary[i-n+height_boundary].apply(src,i);
-      }
-    }
-
+               const unsigned int n) const;
+    /**
+     * Apply the associated "D+" operator of this object, i.e. the operator
+     * defined by reflecting and negating the corresponding matrix.
+     */
     void apply_dp(dealii::Vector<double> &dst,
                   const dealii::Vector<double> &src,
-                  const unsigned int n) const
-    {
-      for(int i = 0; i < height_boundary; ++i) {
-        dst[i] = -rboundary[height_boundary-1-i].apply_fliplr(src,i);
-      }
+                  const unsigned int n) const;
+  };
 
-      for(int i = height_boundary; i < n-height_boundary; ++i) {
-        dst[i] = -interior.apply_fliplr(src,i);
-      }
 
-      for(int i = n-height_boundary; i < n; ++i) {
-        dst[i] = -lboundary[n-1-i].apply_fliplr(src,i);
-      }
+  //---------------------------------------------------------------------------
+  // Implementations
+  //---------------------------------------------------------------------------
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  constexpr Operator<width_interior,width_boundary,height_boundary>
+  ::Operator(const Stencil<width_interior> i,
+             const BlockStencil<width_boundary,height_boundary> l,
+             const BlockStencil<width_boundary,height_boundary> r)
+    :interior(i), lboundary(l), rboundary(r)
+  {}
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  void Operator<width_interior,width_boundary,height_boundary>
+  ::apply(dealii::Vector<double> &dst,
+        const dealii::Vector<double> &src,
+        const unsigned int n) const
+  {
+    for(int i = 0; i < height_boundary; ++i) {
+      dst[i] = lboundary[i].apply(src,i);
     }
 
-  };
+    for(int i = height_boundary; i < n-height_boundary; ++i) {
+      dst[i] = interior.apply(src,i);
+    }
+
+    for(int i = n-height_boundary; i < n; ++i) {
+      dst[i] = rboundary[i-n+height_boundary].apply(src,i);
+    }
+  }
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  void Operator<width_interior,width_boundary,height_boundary>
+  ::apply_dp(dealii::Vector<double> &dst,
+           const dealii::Vector<double> &src,
+           const unsigned int n) const
+  {
+    for(int i = 0; i < height_boundary; ++i) {
+      dst[i] = -rboundary[height_boundary-1-i].apply_fliplr(src,i);
+    }
+
+    for(int i = height_boundary; i < n-height_boundary; ++i) {
+      dst[i] = -interior.apply_fliplr(src,i);
+    }
+
+    for(int i = n-height_boundary; i < n; ++i) {
+      dst[i] = -lboundary[n-1-i].apply_fliplr(src,i);
+    }
+  }
+
 }
 
 #endif /* _OPERATOR_H */

--- a/include/stenseal/operator.h
+++ b/include/stenseal/operator.h
@@ -1,0 +1,74 @@
+/* -*- c-basic-offset:2; tab-width:2; indent-tabs-mode:nil -*-
+ *
+ */
+
+#ifndef _OPERATOR_H
+#define _OPERATOR_H
+
+#include <vector>
+
+#include <deal.II/lac/vector.h>
+
+#include "stenseal/stencil.h"
+#include "stenseal/block_stencil.h"
+
+//=============================================================================
+// this is an operator in 1D
+//=============================================================================
+namespace stenseal
+{
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  class Operator
+  {
+  private:
+    const BlockStencil<width_boundary,height_boundary> lboundary;
+    const BlockStencil<width_boundary,height_boundary> rboundary;
+    const Stencil<width_interior> interior;
+
+  public:
+    constexpr Operator(const Stencil<width_interior> i,
+                       const BlockStencil<width_boundary,height_boundary> l,
+                       const BlockStencil<width_boundary,height_boundary> r)
+      :interior(i), lboundary(l), rboundary(r)
+    {}
+
+    void apply(dealii::Vector<double> &dst,
+               const dealii::Vector<double> &src,
+               const unsigned int n) const
+    {
+      for(int i = 0; i < height_boundary; ++i) {
+        dst[i] = lboundary[i].apply(src,i);
+      }
+
+      for(int i = height_boundary; i < n-height_boundary; ++i) {
+        dst[i] = interior.apply(src,i);
+      }
+
+      for(int i = n-height_boundary; i < n; ++i) {
+        dst[i] = rboundary[i-n+height_boundary].apply(src,i);
+      }
+    }
+
+    void apply_dp(dealii::Vector<double> &dst,
+                  const dealii::Vector<double> &src,
+                  const unsigned int n) const
+    {
+      for(int i = 0; i < height_boundary; ++i) {
+        dst[i] = -rboundary[height_boundary-1-i].apply_fliplr(src,i);
+      }
+
+      for(int i = height_boundary; i < n-height_boundary; ++i) {
+        dst[i] = -interior.apply_fliplr(src,i);
+      }
+
+      for(int i = n-height_boundary; i < n; ++i) {
+        dst[i] = -lboundary[n-1-i].apply_fliplr(src,i);
+      }
+    }
+
+  };
+}
+
+#endif /* _OPERATOR_H */

--- a/include/stenseal/operator.h
+++ b/include/stenseal/operator.h
@@ -29,18 +29,18 @@ namespace stenseal
   class Operator
   {
   private:
-    const BlockStencil<width_boundary,height_boundary> lboundary;
-    const BlockStencil<width_boundary,height_boundary> rboundary;
+    const StencilArray<width_boundary,height_boundary> lboundary;
+    const StencilArray<width_boundary,height_boundary> rboundary;
     const Stencil<width_interior> interior;
   public:
 
     /**
-     * Constructor. Takes the interior `Stencil` `i`, and the `BlockStencil`s
+     * Constructor. Takes the interior `Stencil` `i`, and the `StencilArray`s
      * `l` and `r` for the left and right boundaries respectively.
      */
     constexpr Operator(const Stencil<width_interior> i,
-                       const BlockStencil<width_boundary,height_boundary> l,
-                       const BlockStencil<width_boundary,height_boundary> r);
+                       const StencilArray<width_boundary,height_boundary> l,
+                       const StencilArray<width_boundary,height_boundary> r);
 
     /**
      * Apply this `Operator` to the vector `src` and write the result into
@@ -68,8 +68,8 @@ namespace stenseal
             int height_boundary>
   constexpr Operator<width_interior,width_boundary,height_boundary>
   ::Operator(const Stencil<width_interior> i,
-             const BlockStencil<width_boundary,height_boundary> l,
-             const BlockStencil<width_boundary,height_boundary> r)
+             const StencilArray<width_boundary,height_boundary> l,
+             const StencilArray<width_boundary,height_boundary> r)
     :interior(i), lboundary(l), rboundary(r)
   {}
 

--- a/include/stenseal/stencil.h
+++ b/include/stenseal/stencil.h
@@ -1,0 +1,132 @@
+/* -*- c-basic-offset:2; tab-width:2; indent-tabs-mode:nil -*-
+ *
+ *
+ */
+
+#ifndef _STENCIL_H
+#define _STENCIL_H
+
+#include <array>
+#include <utility>
+
+#include <deal.II/lac/vector.h>
+
+
+namespace stenseal
+{
+
+  //=============================================================================
+  // append to std::array
+  //=============================================================================
+
+  template <typename T, std::size_t N>
+  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t);
+
+  //=============================================================================
+  // infrastructure for expression template
+  //=============================================================================
+
+  struct Accessor {
+    const int offset;
+  };
+
+  struct Symbol
+  {
+    constexpr Accessor operator[](int i) const
+    {
+      return Accessor{i};
+    }
+  };
+
+  struct WeightedTerm
+  {
+    const double weight;
+    const int offset;
+
+    constexpr WeightedTerm(double a, Accessor u)
+      : weight(a), offset(u.offset)
+    {}
+  };
+
+  constexpr WeightedTerm operator*(double a, Accessor u)
+  {
+    return WeightedTerm(a,u);
+  }
+
+  template <int n>
+  struct Sum
+  {
+    const std::array<double,n> weights;
+    const std::array<int,n> offsets;
+
+    constexpr Sum(WeightedTerm x, WeightedTerm y)
+      : weights({x.weight,y.weight}), offsets({x.offset,y.offset})
+    {}
+
+    constexpr Sum(Sum<n-1> x, WeightedTerm y)
+      : weights(append(x.weights,y.weight)), offsets(append(x.offsets,y.offset))
+    {}
+  };
+
+  constexpr Sum<2> operator+(WeightedTerm x, WeightedTerm y)
+  {
+    return Sum<2>(x,y);
+  }
+
+  template <int n>
+  constexpr Sum<n+1> operator+(Sum<n> x, WeightedTerm y)
+  {
+    return Sum<n+1>(x,y);
+  }
+
+  template <int width>
+  struct Stencil
+  {
+    const std::array<double,width> weights;
+    const std::array<int,width> offsets;
+
+    constexpr  Stencil(const Sum<width> s)
+      : weights(s.weights), offsets(s.offsets)
+    {}
+
+    inline double apply(const dealii::Vector<double> &u, int i) const
+    {
+      double t=0;
+      for(int j = 0; j < width; ++j) {
+        t+=u[i+offsets[j]]*weights[j];
+      }
+      return t;
+    }
+
+    inline double apply_fliplr(const dealii::Vector<double> &u, int i) const
+    {
+      double t=0;
+      for(int j = width-1; j >= 0; --j) {
+        t += u[i-offsets[j]]*weights[j];
+      }
+      return t;
+    }
+
+  };
+
+  //=============================================================================
+  // append to std::array
+  //=============================================================================
+
+  template <typename T, std::size_t N, std::size_t... I>
+  constexpr std::array<T, N + 1> append_aux(const std::array<T, N> a, T t,
+                                            const std::index_sequence<I...>)
+  {
+    return std::array<T, N + 1>{ a[I]..., t };
+  }
+
+  template <typename T, std::size_t N>
+  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t)
+  {
+    return append_aux(a, t, std::make_index_sequence<N>());
+  }
+
+
+}
+
+#endif /* _STENCIL_H */

--- a/include/stenseal/stencil.h
+++ b/include/stenseal/stencil.h
@@ -11,16 +11,104 @@
 
 #include <deal.II/lac/vector.h>
 
-
 namespace stenseal
 {
+  // forward declaration
+  template <int n>
+  struct Sum;
+
+  /**
+   * A class representing a single row in an operator, i.e. a weighted
+   * combination of a number elements in the input vector. The template
+   * parameter `width` is the number of non-zeros in the row. It is initialized
+   * using expression templates based on a variable of the `Symbol` type, e.g.
+   *
+   *     const stenseal::Symbol u;
+   *     constexpr stenseal::Stencil<2> interior((-1.0)*u[-1] + 1.0*u[0]);
+   *
+   * Here, the indexing into the symbol `u` should be understood as relative
+   * offsets from the diagonal.
+   *
+   * For performance reasons, all constituents of the expression, i.e. indices
+   * and weights, should be literals or other `constexpr` entities, which can be
+   * enforced by declaring the `Stencil` itself to be `constexpr` as above. If
+   * this is done, very aggressive inlining optimizations can be performed by
+   * the compiler such that no indices or weights must be read from memory
+   * during the stencil application.
+   */
+
+  template <int width>
+  class Stencil
+  {
+  private:
+    const std::array<double,width> weights;
+    const std::array<int,width> offsets;
+  public:
+
+    /**
+     * Constructor. Called with an expression of matching length `width` as
+     * input, which for performance reasons should always be a `constexpr`.
+     */
+    constexpr  Stencil(const Sum<width> s);
+
+    /**
+     * Function for applying this stencil to a vector `u` at position
+     * `i`. Returns the resulting value.
+     */
+    inline double apply(const dealii::Vector<double> &u, int i) const;
+
+    /**
+     * Function for applying the flipped/reversed stencil.
+     */
+    inline double apply_fliplr(const dealii::Vector<double> &u, int i) const;
+  };
+
+  //=============================================================================
+  // Implementations
+  //=============================================================================
+
+  template <int width>
+  constexpr  Stencil<width>::Stencil(const Sum<width> s)
+    : weights(s.weights), offsets(s.offsets)
+  {}
+
+  template <int width>
+  inline double Stencil<width>::apply(const dealii::Vector<double> &u, int i) const
+  {
+    double t=0;
+    for(int j = 0; j < width; ++j) {
+      t+=u[i+offsets[j]]*weights[j];
+    }
+    return t;
+  }
+
+  template <int width>
+  inline double Stencil<width>::apply_fliplr(const dealii::Vector<double> &u, int i) const
+  {
+    double t=0;
+    for(int j = width-1; j >= 0; --j) {
+      t += u[i-offsets[j]]*weights[j];
+    }
+    return t;
+  }
 
   //=============================================================================
   // append to std::array
   //=============================================================================
 
+  template <typename T, std::size_t N, std::size_t... I>
+  constexpr std::array<T, N + 1> append_aux(const std::array<T, N> a, T t,
+                                            const std::index_sequence<I...>)
+  {
+    return std::array<T, N + 1>{ a[I]..., t };
+  }
+
   template <typename T, std::size_t N>
-  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t);
+  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t)
+  {
+    return append_aux(a, t, std::make_index_sequence<N>());
+  }
+
 
   //=============================================================================
   // infrastructure for expression template
@@ -53,6 +141,7 @@ namespace stenseal
     return WeightedTerm(a,u);
   }
 
+
   template <int n>
   struct Sum
   {
@@ -78,54 +167,6 @@ namespace stenseal
   {
     return Sum<n+1>(x,y);
   }
-
-  template <int width>
-  struct Stencil
-  {
-    const std::array<double,width> weights;
-    const std::array<int,width> offsets;
-
-    constexpr  Stencil(const Sum<width> s)
-      : weights(s.weights), offsets(s.offsets)
-    {}
-
-    inline double apply(const dealii::Vector<double> &u, int i) const
-    {
-      double t=0;
-      for(int j = 0; j < width; ++j) {
-        t+=u[i+offsets[j]]*weights[j];
-      }
-      return t;
-    }
-
-    inline double apply_fliplr(const dealii::Vector<double> &u, int i) const
-    {
-      double t=0;
-      for(int j = width-1; j >= 0; --j) {
-        t += u[i-offsets[j]]*weights[j];
-      }
-      return t;
-    }
-
-  };
-
-  //=============================================================================
-  // append to std::array
-  //=============================================================================
-
-  template <typename T, std::size_t N, std::size_t... I>
-  constexpr std::array<T, N + 1> append_aux(const std::array<T, N> a, T t,
-                                            const std::index_sequence<I...>)
-  {
-    return std::array<T, N + 1>{ a[I]..., t };
-  }
-
-  template <typename T, std::size_t N>
-  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t)
-  {
-    return append_aux(a, t, std::make_index_sequence<N>());
-  }
-
 
 }
 


### PR DESCRIPTION
Allt ska funka, så vi borde kunna mergea detta. Kolla exemplen för hur det används. Jag introducerade några nya klasser:

- `Stencil` -- en rad i en operator
- `BlockStencil` -- en eller flera rader i en operator
- `Operator` -- en endimensionell SBP-operator utan kännedom om nät. Innehåller en `Stencil` i det inre, och en `BlockStencil` på varje rand

Jag är inte helt nöjd med namnen på dessa -- det blir dumt med "Block" både i `BlockStencil` och i `*BlockOperator`, och kanske även med "Operator" i både `Operator` och `*BlockOperator`. Förslag på bättre namn är välkomna!