### PR TITLE
General geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ TARGET_LINK_LIBRARIES(benchmarks_1d ${LIBNAME})
 # Tests
 #------------------------------------------------------------------------------
 
+# test vector initialization in geometry
+ADD_EXECUTABLE(test_initialize_vector tests/test_initialize_vector.cc)
+TARGET_LINK_LIBRARIES(test_initialize_vector ${LIBNAME})
+STENSEAL_ADD_TEST(test_initialize_vector)
+
 # test for upwind first derivative in 1D
 ADD_EXECUTABLE(test_1d_first_derivative tests/test_1d_first_derivative.cc)
 TARGET_LINK_LIBRARIES(test_1d_first_derivative ${LIBNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ ADD_EXECUTABLE(test_1d_compact_laplace tests/test_1d_compact_laplace)
 TARGET_LINK_LIBRARIES(test_1d_compact_laplace ${LIBNAME})
 STENSEAL_ADD_TEST(test_1d_compact_laplace)
 
+# test for upwind laplace in 1D for general geometry
+ADD_EXECUTABLE(test_1d_general_upwind_laplace tests/test_1d_general_upwind_laplace.cc)
+TARGET_LINK_LIBRARIES(test_1d_general_upwind_laplace ${LIBNAME})
+STENSEAL_ADD_TEST(test_1d_general_upwind_laplace)
+
 # test for coefficient matrix upwind laplance
 ADD_EXECUTABLE(test_1d_upwind_laplace_matrix tests/test_1d_upwind_laplace_matrix.cc)
 TARGET_LINK_LIBRARIES(test_1d_upwind_laplace_matrix ${LIBNAME})

--- a/examples/benchmarks_1d.cc
+++ b/examples/benchmarks_1d.cc
@@ -20,7 +20,7 @@ void benchmark_operator(OperatorType Dm)
 
   for(unsigned int n=1<<19; n<(1<<23); n<<=1) {
 
-    unsigned int n_nodes[dim] = { n };
+    std::array<unsigned int,dim> n_nodes{ n };
     int n_nodes_tot = n_nodes[0];
     double h = 1.0/(n_nodes_tot-1);
 

--- a/examples/wave-equation.cc
+++ b/examples/wave-equation.cc
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   double ymin = 0;
   double ymax = 1.0;
 
-  unsigned int n_nodes[dim] = { 10, 10 };
+  std::array<unsigned int,dim> n_nodes{ 10, 10 };
   dealii::Point<dim> lower_left(xmin,ymin);
   dealii::Point<dim> upper_right(xmax,ymax);
 

--- a/examples/wave-equation.cc
+++ b/examples/wave-equation.cc
@@ -37,32 +37,6 @@ double InitialValues<dim>::value (const dealii::Point<dim> &p,
   return res;
 }
 
-template <int dim, typename Geometry>
-void initialize( dealii::Vector<double> &u, dealii::Function<dim> &f, const Geometry &g )
-{
-  if(dim==1) {
-    for(int i = 0; i < g.get_n_nodes(0); ++i) {
-      double x;
-      x = i*g.get_h(0) + g.get_lower_left(0);
-      dealii::Point<dim> p(x);
-      u[i] = f.value(p);
-    }
-  } else if(dim==2){
-    for(int i = 0; i < g.get_n_nodes(1); ++i) {
-      for(int j = 0; j < g.get_n_nodes(0); ++j) {
-        double x;
-        double y;
-        x = j*g.get_h(0) + g.get_lower_left(0);
-        y = i*g.get_h(1) + g.get_lower_left(1);
-        dealii::Point<dim> p(x,y);
-        u[g.get_n_nodes(0)*i+j] = f.value(p);
-      }
-    }
-  }
-  else  {
-    AssertThrow(false,dealii::ExcNotImplemented());
-  }
-}
 
 int main(int argc, char *argv[])
 {
@@ -94,7 +68,7 @@ int main(int argc, char *argv[])
   //=============================================================================
   dealii::Vector<double> u(geometry.get_n_nodes_total());
   InitialValues<dim> f;
-  initialize<dim,Geometry>(u,f,geometry);
+  geometry.initialize_vector(u,f);
 
   u.print(std::cout);
 

--- a/include/stenseal/compact_laplace.h
+++ b/include/stenseal/compact_laplace.h
@@ -67,7 +67,7 @@ namespace stenseal
       D2.apply(dst,src,coeff,n);
 
       // divide by h^2
-      const double h2 = geometry.get_h(0)*geometry.get_h(0);
+      const double h2 = geometry.get_mapped_h(0)*geometry.get_mapped_h(0);
       dst /= h2;
     }
     else {

--- a/include/stenseal/compact_laplace.h
+++ b/include/stenseal/compact_laplace.h
@@ -5,6 +5,10 @@
 #ifndef _COMPACT_LAPLACE_H
 #define _COMPACT_LAPLACE_H
 
+#include <deal.II/lac/vector.h>
+
+#include "stenseal/metric_coefficient.h"
+
 namespace stenseal
 {
   /**
@@ -24,6 +28,7 @@ namespace stenseal
     const D2Operator D2;
     const D1Operator D1;
     const Geometry geometry;
+    const MetricCoefficient<dim,Geometry> coeff;
   public:
     /**
    * Constructor. Takes the 1D compact second-derivative SBP operator `d2`, the
@@ -48,7 +53,7 @@ namespace stenseal
   template <int dim, typename D2Operator, typename D1Operator, typename Geometry>
   CompactLaplace<dim,D2Operator,D1Operator,Geometry>
   ::CompactLaplace(const D2Operator d2, const D1Operator d1, const Geometry geom)
-    : D2(d2), D1(d1), geometry(geom)
+    : D2(d2), D1(d1), geometry(geom), coeff(geom,d1)
   {}
 
 
@@ -59,7 +64,7 @@ namespace stenseal
     if(dim == 1) {
       const unsigned int n = geometry.get_n_nodes(0);
 
-      D2.apply(dst,src,geometry.get_metric_coefficient(),n);
+      D2.apply(dst,src,coeff,n);
 
       // divide by h^2
       const double h2 = geometry.get_h(0)*geometry.get_h(0);

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -47,6 +47,32 @@ namespace stenseal
 
   };
 
+  template <int dim>
+  class GeneralGeometry {
+  private:
+    const std::vector<dealii::Point<dim>> nodes;
+    std::array<unsigned int,dim> n_nodes;
+    unsigned int n_nodes_total;
+
+  public:
+
+    GeneralGeometry(const std::array<unsigned int,dim> n_nodes,
+                    const std::vector<dealii::Point<dim>> points);
+
+    unsigned get_n_nodes(int d) const
+    {
+      return n_nodes[d];
+    }
+
+    unsigned get_n_nodes_total() const
+    {
+      return n_nodes_total;
+    }
+
+    void initialize_vector(dealii::Vector<double> &u,
+                           dealii::Function<dim> &f) const;
+
+  };
 
 
   /*

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -11,45 +11,13 @@
 namespace stenseal
 {
 
-  namespace internal
-  {
-    template <std::size_t n, typename T>
-    constexpr std::array<T,n> repeat_value(const T val);
-  }
-
   template <int dim>
   class CartesianGeometry {
-  public:
-    struct MetricCoefficient {
-      constexpr double get(int) const
-      {
-        return 1.0;
-      }
-
-      template <int n>
-      constexpr std::array<double, n> get_centered_array(int) const
-      {
-        return internal::repeat_value<n>(1.0);
-      }
-
-      template <int n>
-      constexpr std::array<double, n> get_left_boundary_array() const
-      {
-        return internal::repeat_value<n>(1.0);
-      }
-
-      template <int n>
-      constexpr std::array<double, n> get_right_boundary_array() const
-      {
-        return internal::repeat_value<n>(1.0);
-      }
-    };
   private:
     double h[dim];
     unsigned int n_nodes[dim];
     unsigned int n_nodes_total;
     dealii::Point<dim> lower_left;
-    MetricCoefficient coefficient;
 
   public:
     // FIXME: add default parameters which are [0,0,0,0....] and [1,1,1,1,...]
@@ -73,11 +41,6 @@ namespace stenseal
     }
 
 
-    inline constexpr const MetricCoefficient& get_metric_coefficient() const
-    {
-      return coefficient;
-    }
-
     inline double get_lower_left(int d) const
     {
       return lower_left(d);
@@ -93,30 +56,8 @@ namespace stenseal
       return h;
     }
   };
-
-  struct GeneralGeometry {
-    double *c;
-    inline double get_c(int i) const
-    {
-      return c[i];
-    }
-    };
   */
 
-  namespace internal
-  {
-    template <std::size_t n, typename T, std::size_t... I>
-    constexpr std::array<T,n> repeat_value_impl(const T val, const std::index_sequence<I...>)
-    {
-      return { (I,val)...};
-    }
-
-    template <std::size_t n, typename T>
-    constexpr std::array<T,n> repeat_value(const T val)
-    {
-      return repeat_value_impl<n>(val,std::make_index_sequence<n>());
-    }
-  }
 
 }
 

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -14,7 +14,8 @@ namespace stenseal
 {
 
   template <int dim>
-  class CartesianGeometry {
+  class CartesianGeometry
+  {
   private:
     std::array<double,dim> h;
     std::array<unsigned int,dim> n_nodes;
@@ -43,12 +44,13 @@ namespace stenseal
     }
 
     void initialize_vector(dealii::Vector<double> &u,
-                           dealii::Function<dim> &f) const;
+                           const dealii::Function<dim> &f) const;
 
   };
 
   template <int dim>
-  class GeneralGeometry {
+  class GeneralGeometry
+  {
   private:
     const std::vector<dealii::Point<dim>> nodes;
     std::array<unsigned int,dim> n_nodes;
@@ -70,7 +72,7 @@ namespace stenseal
     }
 
     void initialize_vector(dealii::Vector<double> &u,
-                           dealii::Function<dim> &f) const;
+                           const dealii::Function<dim> &f) const;
 
   };
 

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -12,6 +12,12 @@
 
 namespace stenseal
 {
+  namespace internal
+  {
+    template <int dim>
+    dealii::Point<dim> repeat_point(double d);
+  }
+
 
   template <int dim>
   class CartesianGeometry
@@ -23,10 +29,10 @@ namespace stenseal
     dealii::Point<dim> lower_left;
 
   public:
-    // FIXME: add default parameters which are [0,0,0,0....] and [1,1,1,1,...]
+
     CartesianGeometry(const std::array<unsigned int,dim> n_nodes,
-                      const dealii::Point<dim> lower_left,
-                      const dealii::Point<dim> upper_right);
+                      const dealii::Point<dim> lower_left=internal::repeat_point<dim>(0.0),
+                      const dealii::Point<dim> upper_right=internal::repeat_point<dim>(1.0));
 
     unsigned get_n_nodes(int d) const
     {

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -34,20 +34,11 @@ namespace stenseal
                       const dealii::Point<dim> lower_left=internal::repeat_point<dim>(0.0),
                       const dealii::Point<dim> upper_right=internal::repeat_point<dim>(1.0));
 
-    unsigned get_n_nodes(int d) const
-    {
-      return n_nodes[d];
-    }
+    unsigned get_n_nodes(int d) const;
 
-    unsigned get_n_nodes_total() const
-    {
-      return n_nodes_total;
-    }
+    unsigned get_n_nodes_total() const;
 
-    double get_h(int d) const
-    {
-      return h[d];
-    }
+    double get_mapped_h(int d) const;
 
     void initialize_vector(dealii::Vector<double> &u,
                            const dealii::Function<dim> &f) const;
@@ -64,21 +55,20 @@ namespace stenseal
     const std::vector<dealii::Point<dim>> nodes;
     std::array<unsigned int,dim> n_nodes;
     unsigned int n_nodes_total;
+    std::array<double,dim> h_mapped;
 
   public:
 
     GeneralGeometry(const std::array<unsigned int,dim> n_nodes,
                     const std::vector<dealii::Point<dim>> points);
 
-    unsigned get_n_nodes(int d) const
-    {
-      return n_nodes[d];
-    }
+    unsigned get_n_nodes(int d) const;
 
-    unsigned get_n_nodes_total() const
-    {
-      return n_nodes_total;
-    }
+    unsigned get_n_nodes_total() const;
+
+    double get_mapped_h(int d) const;
+
+    const std::vector<dealii::Point<dim>>& get_node_points() const;
 
     void initialize_vector(dealii::Vector<double> &u,
                            const dealii::Function<dim> &f) const;

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -6,7 +6,9 @@
 #ifndef _GEOMETRY_H
 #define _GEOMETRY_H
 
+#include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
+#include <deal.II/lac/vector.h>
 
 namespace stenseal
 {
@@ -25,28 +27,27 @@ namespace stenseal
                       const dealii::Point<dim> lower_left,
                       const dealii::Point<dim> upper_right);
 
-    inline unsigned get_n_nodes(int d) const
+    unsigned get_n_nodes(int d) const
     {
       return n_nodes[d];
     }
 
-    inline unsigned get_n_nodes_total() const
+    unsigned get_n_nodes_total() const
     {
       return n_nodes_total;
     }
 
-    inline double get_h(int d) const
+    double get_h(int d) const
     {
       return h[d];
     }
 
-
-    inline double get_lower_left(int d) const
-    {
-      return lower_left(d);
-    }
+    void initialize_vector(dealii::Vector<double> &u,
+                           dealii::Function<dim> &f) const;
 
   };
+
+
 
   /*
   struct TransfiniteInterpolationGeometry {

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -16,14 +16,14 @@ namespace stenseal
   template <int dim>
   class CartesianGeometry {
   private:
-    double h[dim];
-    unsigned int n_nodes[dim];
+    std::array<double,dim> h;
+    std::array<unsigned int,dim> n_nodes;
     unsigned int n_nodes_total;
     dealii::Point<dim> lower_left;
 
   public:
     // FIXME: add default parameters which are [0,0,0,0....] and [1,1,1,1,...]
-    CartesianGeometry(unsigned int n_nodes[dim],
+    CartesianGeometry(const std::array<unsigned int,dim> n_nodes,
                       const dealii::Point<dim> lower_left,
                       const dealii::Point<dim> upper_right);
 

--- a/include/stenseal/geometry.h
+++ b/include/stenseal/geometry.h
@@ -46,6 +46,9 @@ namespace stenseal
     void initialize_vector(dealii::Vector<double> &u,
                            const dealii::Function<dim> &f) const;
 
+    void initialize_vector(dealii::Vector<double> &u,
+                           const std::function<double (const dealii::Point<dim> &)> &f) const;
+
   };
 
   template <int dim>
@@ -74,6 +77,8 @@ namespace stenseal
     void initialize_vector(dealii::Vector<double> &u,
                            const dealii::Function<dim> &f) const;
 
+    void initialize_vector(dealii::Vector<double> &u,
+                           const std::function<double (const dealii::Point<dim> &)> &f) const;
   };
 
 

--- a/include/stenseal/metric_coefficient.h
+++ b/include/stenseal/metric_coefficient.h
@@ -50,6 +50,71 @@ namespace stenseal
     }
   };
 
+  template <int dim>
+  struct MetricCoefficient<dim,GeneralGeometry<dim>>
+  {
+  private:
+    std::vector<double> c;
+    unsigned int n_points;
+
+  public:
+    template <typename DmOp>
+    MetricCoefficient(const GeneralGeometry<dim> &g, const DmOp &op);
+
+    double get(int i) const
+    {
+      return c[i];
+    }
+
+    template <int n>
+      std::array<double, n> get_centered_array(int i) const
+    {
+      std::array<double, n> res;
+      const std::array<int, n> &offsets = internal::gen_offsets<n>::value;
+      for(int j = 0; j < n; ++j)
+        res[j] = c[i+offsets[j]];
+      return res;
+    }
+
+    template <int n>
+      std::array<double, n> get_left_boundary_array() const
+    {
+      std::array<double, n> res;
+      for(int j = 0; j < n; ++j)
+        res[j] = c[j];
+      return res;
+    }
+
+    template <int n>
+      std::array<double, n> get_right_boundary_array() const
+    {
+      std::array<double, n> res;
+      for(int j = 0; j < n; ++j)
+        res[j] = c[n_points-n+j];
+      return res;
+    }
+  };
+
+
+  template <int dim>
+  template <typename DmOp>
+  MetricCoefficient<dim,GeneralGeometry<dim>>::MetricCoefficient(const GeneralGeometry<dim> &g, const DmOp &op)
+  {
+    if(dim==1) {
+      const std::vector<dealii::Point<dim>> &pts = g.get_points();
+      const unsigned int npts = pts.size();
+      std::vector<double> xvals(npts);
+
+      for(int i=0; i<npts; ++i)
+        xvals[i] = pts[i](0);
+
+      c.resize(npts);
+      op.apply(c,xvals);
+    }
+    else {
+      AssertThrow(false,dealii::ExcNotImplemented());
+    }
+  }
 
 
   namespace internal

--- a/include/stenseal/metric_coefficient.h
+++ b/include/stenseal/metric_coefficient.h
@@ -1,0 +1,72 @@
+/* -*- c-basic-offset:2; tab-width:2; indent-tabs-mode:nil -*-
+ *
+ */
+
+#ifndef _METRIC_COEFFICIENT_H
+#define _METRIC_COEFFICIENT_H
+
+#include <array>
+
+#include "stenseal/geometry.h"
+
+namespace stenseal
+{
+  namespace internal
+  {
+    template <std::size_t n, typename T>
+    constexpr std::array<T,n> repeat_value(const T val);
+  }
+
+  template <int dim, typename Geometry>
+  struct MetricCoefficient;
+
+  template <int dim>
+  struct MetricCoefficient<dim,CartesianGeometry<dim>>
+  {
+    template <typename dummy>
+    constexpr MetricCoefficient(const CartesianGeometry<dim>&, const dummy&) {}
+
+    constexpr double get(int) const
+    {
+      return 1.0;
+    }
+
+    template <int n>
+      constexpr std::array<double, n> get_centered_array(int) const
+    {
+      return internal::repeat_value<n>(1.0);
+    }
+
+    template <int n>
+      constexpr std::array<double, n> get_left_boundary_array() const
+    {
+      return internal::repeat_value<n>(1.0);
+    }
+
+    template <int n>
+      constexpr std::array<double, n> get_right_boundary_array() const
+    {
+      return internal::repeat_value<n>(1.0);
+    }
+  };
+
+
+
+  namespace internal
+  {
+    template <std::size_t n, typename T, std::size_t... I>
+    constexpr std::array<T,n> repeat_value_impl(const T val, const std::index_sequence<I...>)
+    {
+      return { (I,val)...};
+    }
+
+    template <std::size_t n, typename T>
+    constexpr std::array<T,n> repeat_value(const T val)
+    {
+      return repeat_value_impl<n>(val,std::make_index_sequence<n>());
+    }
+  }
+
+}
+
+#endif /* _METRIC_COEFFICIENT_H */

--- a/include/stenseal/metric_coefficient.h
+++ b/include/stenseal/metric_coefficient.h
@@ -126,8 +126,6 @@ namespace stenseal
       op.apply(c,xvals,n_points);
       c /= g.get_mapped_h(0);
 
-      std::cout << "Metric coefficient:" << std::endl;
-      c.print(std::cout);
     }
     else {
       AssertThrow(false,dealii::ExcNotImplemented());

--- a/include/stenseal/stencil.h
+++ b/include/stenseal/stencil.h
@@ -90,8 +90,11 @@ namespace stenseal
   // Implementations
   //=============================================================================
 
-  template <int m>
-  struct gen_offsets;
+  namespace internal
+  {
+    template <int m>
+    struct gen_offsets;
+  }
 
 
   template <int width>
@@ -101,7 +104,7 @@ namespace stenseal
 
   template <int width>
   constexpr  Stencil<width>::Stencil(const std::array<double,width> w)
-    : weights(w), offsets(gen_offsets<width>::value)
+    : weights(w), offsets(internal::gen_offsets<width>::value)
   {}
 
   template <int width>
@@ -189,30 +192,33 @@ namespace stenseal
     return prepend_aux(t,a, std::make_index_sequence<N>());
   }
 
-  // generate contiguous list of offsets centered around 0
-  template <>
-  struct gen_offsets<1>
+  namespace internal
   {
-    static constexpr std::array<int,1> value{0};
-  };
+    // generate contiguous list of offsets centered around 0
+    template <>
+    struct gen_offsets<1>
+    {
+      static constexpr std::array<int,1> value{0};
+    };
 
-  template <>
-  struct gen_offsets<2>
-  {
-    static constexpr std::array<int,2> value{0,1};
-  };
+    template <>
+    struct gen_offsets<2>
+    {
+      static constexpr std::array<int,2> value{0,1};
+    };
 
-  template <int m>
-  struct gen_offsets
-  {
-    static constexpr std::array<int,m> value = prepend((m%2==0)-m/2, append(gen_offsets<m-2>::value, m/2));
-  };
+    template <int m>
+    struct gen_offsets
+    {
+      static constexpr std::array<int,m> value = prepend((m%2==0)-m/2, append(gen_offsets<m-2>::value, m/2));
+    };
 
-  template <int m>
-  constexpr std::array<int,m> gen_offsets<m>::value;
+    template <int m>
+    constexpr std::array<int,m> gen_offsets<m>::value;
 
-  constexpr std::array<int,1> gen_offsets<1>::value;
-  constexpr std::array<int,2> gen_offsets<2>::value;
+    constexpr std::array<int,1> gen_offsets<1>::value;
+    constexpr std::array<int,2> gen_offsets<2>::value;
+  }
 
 
   //=============================================================================

--- a/include/stenseal/upwind_laplace.h
+++ b/include/stenseal/upwind_laplace.h
@@ -7,9 +7,11 @@
 #define _UPWIND_LAPLACE_H
 
 #include <deal.II/lac/vector.h>
-#include "stenseal/geometry.h"
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
+
+#include "stenseal/geometry.h"
+#include "stenseal/metric_coefficient.h"
 
 namespace stenseal
 {
@@ -25,6 +27,7 @@ namespace stenseal
   private:
     const DmT Dm;
     const Geometry geometry;
+    const MetricCoefficient<dim,Geometry> coeff;
 
   public:
     /**
@@ -52,7 +55,7 @@ namespace stenseal
   template <int dim, typename DmT, typename Geometry>
   UpwindLaplace<dim,DmT,Geometry>
   ::UpwindLaplace(const DmT dm, const Geometry &g)
-    : Dm(dm), geometry(g)
+    : Dm(dm), geometry(g), coeff(g,dm)
   {}
 
 
@@ -84,7 +87,6 @@ namespace stenseal
 
       // stupid inefficient way of multiplying with c and 1/h^2
       // FIXME: merge with above.
-      const auto &coeff = geometry.get_metric_coefficient();
       for(int i = 0; i<n; ++i) {
         tmp[i] *= coeff.get(i);
       }

--- a/include/stenseal/upwind_laplace.h
+++ b/include/stenseal/upwind_laplace.h
@@ -88,7 +88,7 @@ namespace stenseal
       // stupid inefficient way of multiplying with c and 1/h^2
       // FIXME: merge with above.
       for(int i = 0; i<n; ++i) {
-        tmp[i] *= coeff.get(i);
+        tmp[i] /= coeff.get(i);
       }
 
       //-------------------------------------------------------------------------
@@ -97,7 +97,10 @@ namespace stenseal
       Dm.apply_dp(dst,tmp,n);
 
       const double h2 = geometry.get_mapped_h(0)*geometry.get_mapped_h(0);
-      dst /= h2;
+
+      for(int i = 0; i<n; ++i) {
+        dst[i] /= coeff.get(i)*h2;
+      }
 
     }
     else {

--- a/include/stenseal/upwind_laplace.h
+++ b/include/stenseal/upwind_laplace.h
@@ -96,7 +96,7 @@ namespace stenseal
       //-------------------------------------------------------------------------
       Dm.apply_dp(dst,tmp,n);
 
-      const double h2 = geometry.get_h(0)*geometry.get_h(0);
+      const double h2 = geometry.get_mapped_h(0)*geometry.get_mapped_h(0);
       dst /= h2;
 
     }

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -17,22 +17,37 @@ namespace stenseal {
 
   template <int dim>
   void CartesianGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
-                                                 dealii::Function<dim> &f) const
+                                                 const dealii::Function<dim> &f) const
   {
     if(dim==1) {
       for(int i = 0; i < n_nodes[0]; ++i) {
-        double x = i*h[0] + lower_left(0);
-        dealii::Point<dim> p(x);
+        const double x = i*h[0] + lower_left(0);
+        const dealii::Point<dim> p(x);
         u[i] = f.value(p);
       }
     }
     else if(dim==2){
-      for(int i = 0; i < n_nodes[1]; ++i) {
-        for(int j = 0; j < n_nodes[0]; ++j) {
-          double x = j*h[0] + lower_left(0);
-          double y = i*h[1] + lower_left(1);
-          dealii::Point<dim> p(x,y);
-          u[n_nodes[0]*i+j] = f.value(p);
+      for(int iy = 0; iy < n_nodes[1]; ++iy) {
+        for(int ix = 0; ix < n_nodes[0]; ++ix) {
+          const double x = ix*h[0] + lower_left(0);
+          const double y = iy*h[1] + lower_left(1);
+          const dealii::Point<dim> p(x,y);
+          const int idx = iy*n_nodes[0]+ix;
+          u[idx] = f.value(p);
+        }
+      }
+    }
+    else if(dim==3){
+      for(int iz = 0; iz < n_nodes[2]; ++iz) {
+        for(int iy = 0; iy < n_nodes[1]; ++iy) {
+          for(int ix = 0; ix < n_nodes[0]; ++ix) {
+            const double x = ix*h[0] + lower_left(0);
+            const double y = iy*h[1] + lower_left(1);
+            const double z = iz*h[2] + lower_left(2);
+            const dealii::Point<dim> p(x,y,z);
+            const int idx = (iz*n_nodes[1] + iy)*n_nodes[0]+ix;
+            u[idx] = f.value(p);
+          }
         }
       }
     }
@@ -55,7 +70,7 @@ namespace stenseal {
 
   template <int dim>
   void GeneralGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
-                                               dealii::Function<dim> &f) const
+                                               const dealii::Function<dim> &f) const
   {
     if(dim<4 && dim>0) {
       for(int i = 0; i < n_nodes_total; ++i) {
@@ -70,8 +85,10 @@ namespace stenseal {
 
   template class CartesianGeometry<1>;
   template class CartesianGeometry<2>;
+  template class CartesianGeometry<3>;
 
   template class GeneralGeometry<1>;
   template class GeneralGeometry<2>;
+  template class GeneralGeometry<3>;
 
 }

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -1,4 +1,5 @@
 #include "stenseal/geometry.h"
+#include <deal.II/base/function.h>
 
 namespace stenseal {
 
@@ -13,6 +14,13 @@ namespace stenseal {
       n_nodes_total *=n_nodes[d];
       h[d] = (upper_right[d]-lower_left[d])/(n_nodes[d]-1);
     }
+  }
+
+  template <int dim>
+  void CartesianGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
+                                                 const std::function<double (const dealii::Point<dim>&)> &f) const
+  {
+    initialize_vector(u, dealii::ScalarFunctionFromFunctionObject<dim>(f));
   }
 
   template <int dim>
@@ -66,6 +74,13 @@ namespace stenseal {
     for(int d = 0; d < dim; ++d) {
       n_nodes_total *=n_nodes[d];
     }
+  }
+
+  template <int dim>
+  void GeneralGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
+                                               const std::function<double (const dealii::Point<dim>&)> &f) const
+  {
+    initialize_vector(u, dealii::ScalarFunctionFromFunctionObject<dim>(f));
   }
 
   template <int dim>

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -3,15 +3,14 @@
 namespace stenseal {
 
   template <int dim>
-  CartesianGeometry<dim>::CartesianGeometry(unsigned int n_nodes[dim],
+  CartesianGeometry<dim>::CartesianGeometry(const std::array<unsigned int,dim> n_nodes,
                                             const dealii::Point<dim> lower_left,
                                             const dealii::Point<dim> upper_right)
+    : n_nodes(n_nodes), lower_left(lower_left)
   {
-    this->lower_left=lower_left;
-    this->n_nodes_total=1;
+    n_nodes_total=1;
     for(int d = 0; d < dim; ++d) {
-      this->n_nodes[d] = n_nodes[d];
-      this->n_nodes_total *=n_nodes[d];
+      n_nodes_total *=n_nodes[d];
       h[d] = (upper_right[d]-lower_left[d])/(n_nodes[d]-1);
     }
   }

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -97,6 +97,27 @@ namespace stenseal {
     }
   }
 
+  namespace internal
+  {
+    template <>
+    dealii::Point<1> repeat_point(double d)
+    {
+      return dealii::Point<1>(d);
+    }
+
+    template <>
+    dealii::Point<2> repeat_point(double d)
+    {
+      return dealii::Point<2>(d,d);
+    }
+
+    template <>
+    dealii::Point<3> repeat_point(double d)
+    {
+      return dealii::Point<3>(d,d,d);
+    }
+
+  }
 
   template class CartesianGeometry<1>;
   template class CartesianGeometry<2>;

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -16,6 +16,32 @@ namespace stenseal {
     }
   }
 
+  template <int dim>
+  void CartesianGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
+                                                 dealii::Function<dim> &f) const
+  {
+    if(dim==1) {
+      for(int i = 0; i < n_nodes[0]; ++i) {
+        double x = i*h[0] + lower_left(0);
+        dealii::Point<dim> p(x);
+        u[i] = f.value(p);
+      }
+    }
+    else if(dim==2){
+      for(int i = 0; i < n_nodes[1]; ++i) {
+        for(int j = 0; j < n_nodes[0]; ++j) {
+          double x = j*h[0] + lower_left(0);
+          double y = i*h[1] + lower_left(1);
+          dealii::Point<dim> p(x,y);
+          u[n_nodes[0]*i+j] = f.value(p);
+        }
+      }
+    }
+    else {
+      AssertThrow(false,dealii::ExcNotImplemented());
+    }
+  }
+
 
   template class CartesianGeometry<1>;
   template class CartesianGeometry<2>;

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -3,6 +3,8 @@
 
 namespace stenseal {
 
+  // cartesian geometry
+
   template <int dim>
   CartesianGeometry<dim>::CartesianGeometry(const std::array<unsigned int,dim> n_nodes,
                                             const dealii::Point<dim> lower_left,
@@ -14,6 +16,24 @@ namespace stenseal {
       n_nodes_total *=n_nodes[d];
       h[d] = (upper_right[d]-lower_left[d])/(n_nodes[d]-1);
     }
+  }
+
+  template <int dim>
+  unsigned CartesianGeometry<dim>::get_n_nodes(int d) const
+  {
+    return n_nodes[d];
+  }
+
+  template <int dim>
+  unsigned CartesianGeometry<dim>::get_n_nodes_total() const
+  {
+    return n_nodes_total;
+  }
+
+  template <int dim>
+  double CartesianGeometry<dim>::get_mapped_h(int d) const
+  {
+    return h[d];
   }
 
   template <int dim>
@@ -64,6 +84,7 @@ namespace stenseal {
     }
   }
 
+  // general geometry
 
   template <int dim>
   GeneralGeometry<dim>::GeneralGeometry(const std::array<unsigned int,dim> n_nodes,
@@ -73,7 +94,32 @@ namespace stenseal {
     n_nodes_total=1;
     for(int d = 0; d < dim; ++d) {
       n_nodes_total *=n_nodes[d];
+      h_mapped[d] = 1.0/(n_nodes[0]-1);
     }
+  }
+
+  template <int dim>
+  unsigned GeneralGeometry<dim>::get_n_nodes(int d) const
+  {
+    return n_nodes[d];
+  }
+
+  template <int dim>
+  unsigned GeneralGeometry<dim>::get_n_nodes_total() const
+  {
+    return n_nodes_total;
+  }
+
+  template <int dim>
+  double GeneralGeometry<dim>::get_mapped_h(int d) const
+  {
+    return h_mapped[d];
+  }
+
+  template <int dim>
+  const std::vector<dealii::Point<dim>>& GeneralGeometry<dim>::get_node_points() const
+  {
+    return nodes;
   }
 
   template <int dim>

--- a/source/geometry.cc
+++ b/source/geometry.cc
@@ -42,7 +42,36 @@ namespace stenseal {
   }
 
 
+  template <int dim>
+  GeneralGeometry<dim>::GeneralGeometry(const std::array<unsigned int,dim> n_nodes,
+                                        const std::vector<dealii::Point<dim>> points)
+    : n_nodes(n_nodes), nodes(points)
+  {
+    n_nodes_total=1;
+    for(int d = 0; d < dim; ++d) {
+      n_nodes_total *=n_nodes[d];
+    }
+  }
+
+  template <int dim>
+  void GeneralGeometry<dim>::initialize_vector(dealii::Vector<double> &u,
+                                               dealii::Function<dim> &f) const
+  {
+    if(dim<4 && dim>0) {
+      for(int i = 0; i < n_nodes_total; ++i) {
+        u[i] = f.value(nodes[i]);
+      }
+    }
+    else {
+      AssertThrow(false,dealii::ExcNotImplemented());
+    }
+  }
+
+
   template class CartesianGeometry<1>;
   template class CartesianGeometry<2>;
+
+  template class GeneralGeometry<1>;
+  template class GeneralGeometry<2>;
 
 }

--- a/tests/test_1d_compact_laplace.cc
+++ b/tests/test_1d_compact_laplace.cc
@@ -18,7 +18,7 @@ void compute_l2_norm(std::pair<OperatorTypeD2,OperatorTypeD1> ops, unsigned int 
 {
   const int dim = 1;
 
-  unsigned int n_nodes[dim] = { n };
+  std::array<unsigned int,dim> n_nodes{ n };
   int n_nodes_tot = n_nodes[0];
   double h = 1.0/(n_nodes_tot-1);
   const double PI = dealii::numbers::PI;

--- a/tests/test_1d_first_derivative.cc
+++ b/tests/test_1d_first_derivative.cc
@@ -15,7 +15,7 @@ void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l
 {
   const int dim = 1;
 
-  unsigned int n_nodes[dim] = { n };
+  std::array<unsigned int,dim> n_nodes{ n };
   int n_nodes_tot = n_nodes[0];
   double h = 1.0/(n_nodes_tot-1);
   const double PI = dealii::numbers::PI;

--- a/tests/test_1d_general_upwind_laplace.cc
+++ b/tests/test_1d_general_upwind_laplace.cc
@@ -1,0 +1,175 @@
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/base/numbers.h>
+
+#include "stenseal/operator.h"
+#include "stenseal/upwind_laplace.h"
+#include "stenseal/operator_lib.h"
+
+/**
+ * Test second order upwind laplace
+ */
+
+template <typename OperatorType>
+void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l2_norm_interior)
+{
+  const int dim = 1;
+
+  std::array<unsigned int,dim> n_nodes{ n };
+  int n_nodes_tot = n_nodes[0];
+  double h = 1.0/(n_nodes_tot-1);
+  const double PI = dealii::numbers::PI;
+
+  // node positions
+  std::vector<dealii::Point<dim>> nodes(n_nodes_tot);
+
+  {
+    // use cartesian geometry to set up initial points
+    stenseal::CartesianGeometry<dim> g(n_nodes);
+
+    dealii::Vector<double> xpos(n_nodes_tot);
+    g.initialize_vector(xpos,[] (const dealii::Point<dim> &p) { return p(0); });
+
+    // end points
+    nodes[0](0) = 0.0;
+    nodes[n_nodes[0]-1](0) = 1.0;
+
+    // jitter interior points
+    for(int i = 1; i < n_nodes[0]-1; ++i) {
+      double urand = (double)rand()/RAND_MAX;
+      nodes[i](0) = xpos[i] +  0.3*g.get_mapped_h(0)*(2.0*urand - 1.0);
+    }
+  }
+
+  std::cout << "Points:" << std::endl;
+  for(auto p : nodes)
+    std::cout << p << std::endl;
+
+  typedef stenseal::GeneralGeometry<dim> Geometry;
+  Geometry geometry(n_nodes,nodes);
+
+  stenseal::UpwindLaplace<dim,OperatorType,Geometry> op(Dm,geometry);
+
+  dealii::Vector<double> u(n_nodes_tot);
+
+  auto test_function =
+    [=](const dealii::Point<dim> &p) { return sin(PI*p(0)); };
+  auto test_function_2nd_derivative =
+    [=](const dealii::Point<dim> &p) { return -PI*PI*sin(PI*p(0)); };
+
+  geometry.initialize_vector(u,test_function);
+
+  dealii::Vector<double> v(n_nodes_tot);
+
+  op.apply(v,u);
+
+
+
+  dealii::Vector<double> vref(n_nodes_tot);
+  geometry.initialize_vector(vref,test_function_2nd_derivative);
+
+  std::cout << "u:" << std::endl;
+  u.print(std::cout);
+
+  std::cout << "v:" << std::endl;
+  v.print(std::cout);
+
+  std::cout << "vref:" << std::endl;
+  vref.print(std::cout);
+
+  // exclude points affected by boundary stencil
+  const int height_r = OperatorType::height_r;
+  const int height_l = OperatorType::height_l;
+  const int width_i =  OperatorType::width_i;
+  const int left_offset = height_l +width_i-1;
+  const int right_offset = height_r + width_i - 1;
+
+  // compute norms
+  double sqsum = 0;
+  double a;
+  for(int i = left_offset; i < n_nodes_tot-right_offset; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+  l2_norm_interior = std::sqrt(h*sqsum);
+
+  for(int i= 0; i < left_offset; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+
+  for(int i = n_nodes_tot-right_offset; i < n_nodes_tot; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+  l2_norm = std::sqrt(h*sqsum);
+}
+
+
+template <typename OperatorType>
+bool test_operator(OperatorType op, float interior_p_ref, float full_p_ref)
+{
+  const int n_tests = 2;
+  double full_norms[n_tests];
+  double interior_norms[n_tests];
+  unsigned int size = 40;
+
+  for(int i=0; i<n_tests; i++) {
+    compute_l2_norm(op,size,full_norms[i],interior_norms[i]);
+    size *= 2;
+  }
+
+  printf("     n   full error   factor  (p)   inter. error   factor   (p)\n");
+  printf(" ---------------------------------------------------------------\n");
+
+  size=40;
+  printf("%6d %12.4g       - ( - )   %12.4g        - ( - )\n",size,full_norms[0],interior_norms[0]);
+  size *= 2;
+
+  bool all_conv = true;
+  double tol = 1e-08;
+  for(int i=1; i<n_tests; i++) {
+    double full_conv = full_norms[i-1] / full_norms[i];
+    double full_p = std::log2(full_conv);
+    double interior_conv = interior_norms[i-1] / interior_norms[i];
+    double interior_p = std::log2(interior_conv);
+    printf("%6d %12.4g %7.3g (%.1f)   %12.4g %8.3g (%.1f)\n",size,full_norms[i],full_conv,full_p,
+           interior_norms[i],interior_conv,interior_p);
+
+    size *= 2;
+    all_conv = all_conv && (interior_p > interior_p_ref && full_p > full_p_ref);
+    if(interior_norms[i] < tol) break;
+  }
+  printf("\n");
+  return all_conv;
+}
+
+int main(int argc, char *argv[])
+{
+  bool all_conv = true;
+
+  printf("Second order Upwind:\n");
+  all_conv = test_operator(stenseal::upwind_operator_2nd_order(),1.9,1.4) && all_conv;
+
+  // printf("\n Kalles Second order Upwind:\n");
+  // all_conv = test_operator(stenseal::upwind_operator_2nd_order_kalle(),1.9,1.4) && all_conv;
+
+  // printf("\n Third order Upwind:\n");
+  // all_conv = test_operator(stenseal::upwind_operator_3rd_order(),2.9,1.4) && all_conv;
+
+  // printf("\n Fourth order Upwind:\n");
+  // all_conv = test_operator(stenseal::upwind_operator_4th_order(),3.9,1.40) && all_conv;
+
+
+  if(all_conv) {
+    printf("Proper convergence order attained\n");
+    return 0;
+  }
+  else {
+    printf("Proper convergence NOT attained\n");
+    return 1;
+  }
+}

--- a/tests/test_1d_upwind_laplace.cc
+++ b/tests/test_1d_upwind_laplace.cc
@@ -15,7 +15,7 @@ void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l
 {
   const int dim = 1;
 
-  unsigned int n_nodes[dim] = { n };
+  std::array<unsigned int,dim> n_nodes{ n };
   int n_nodes_tot = n_nodes[0];
   double h = 1.0/(n_nodes_tot-1);
   const double PI = dealii::numbers::PI;

--- a/tests/test_1d_upwind_laplace.cc
+++ b/tests/test_1d_upwind_laplace.cc
@@ -20,26 +20,26 @@ void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l
   double h = 1.0/(n_nodes_tot-1);
   const double PI = dealii::numbers::PI;
 
-  // FIXME: call without points once default values are supported
   typedef stenseal::CartesianGeometry<dim> Geometry;
-  Geometry geometry(n_nodes, dealii::Point<dim>(0.0),
-                    dealii::Point<dim>(1.0));
+  Geometry geometry(n_nodes);
 
   stenseal::UpwindLaplace<dim,OperatorType,Geometry> op(Dm,geometry);
 
   dealii::Vector<double> u(n_nodes_tot);
 
-  auto test_function = [=](double x) { return sin(PI*x); };
-  auto test_function_second_derivative = [=](double x) { return -PI*PI*sin(PI*x); };
+  auto test_function =
+    [=](const dealii::Point<dim> &p) { return sin(PI*p(0)); };
+  auto test_function_2nd_derivative =
+    [=](const dealii::Point<dim> &p) { return -PI*PI*sin(PI*p(0)); };
 
-
-  for(int i = 0; i < n_nodes_tot; ++i) {
-    u[i] = test_function(i*h);
-  }
+  geometry.initialize_vector(u,test_function);
 
   dealii::Vector<double> v(n_nodes_tot);
 
   op.apply(v,u);
+
+  dealii::Vector<double> vref(n_nodes_tot);
+  geometry.initialize_vector(vref,test_function_2nd_derivative);
 
   // exclude points affected by boundary stencil
   const int height_r = OperatorType::height_r;
@@ -52,20 +52,20 @@ void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l
   double sqsum = 0;
   double a;
   for(int i = left_offset; i < n_nodes_tot-right_offset; ++i) {
-    a = v[i] - test_function_second_derivative(i*h);
+    a = v[i] - vref[i];
     sqsum += a*a;
   }
 
   l2_norm_interior = std::sqrt(h*sqsum);
 
   for(int i= 0; i < left_offset; ++i) {
-    a = v[i] - test_function_second_derivative(i*h);
+    a = v[i] - vref[i];
     sqsum += a*a;
   }
 
 
   for(int i = n_nodes_tot-right_offset; i < n_nodes_tot; ++i) {
-    a = v[i] - test_function_second_derivative(i*h);
+    a = v[i] - vref[i];
     sqsum += a*a;
   }
 

--- a/tests/test_initialize_vector.cc
+++ b/tests/test_initialize_vector.cc
@@ -1,0 +1,325 @@
+
+#include <deal.II/base/point.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/base/function.h>
+
+#include "stenseal/geometry.h"
+#include "stenseal/operator.h"
+#include "stenseal/metric_coefficient.h"
+
+#include <fstream>
+
+
+double uref_cartesian_1d[] = {
+ 2.641215290314e-02,    1.269288388934e+00,    2.486291455265e+00,    1.269288388934e+00,
+ 2.641215290314e-02};
+
+double uref_cartesian_2d[] = {
+   1.591246589136e-02,    1.509919021644e-01,    3.182493105568e-02,    1.509918998654e-01,
+   1.591246564901e-02,    1.509919021644e-01,    1.432748030873e+00,    3.019651681488e-01,
+   1.432571281166e+00,    1.509732705833e-01,    3.182493105568e-02,    3.019651681488e-01,
+   4.773739622000e-02,    1.510105314466e-01,    1.591246589136e-02,    1.509918998654e-01,
+   1.432571281166e+00,    1.510105314466e-01,    3.535648615742e-04,    1.863388106479e-05,
+   1.591246564901e-02,    1.509732705833e-01,    1.591246589136e-02,    1.863388106479e-05,
+   4.846930553549e-10};
+
+double uref_cartesian_3d[] = {
+   3.638778236171e-05,    1.403631607185e-04,    6.014885512534e-06,    3.105685301287e-09,
+   2.555827830023e-11,    3.452376812711e-04,    1.331728728121e-03,    5.706765938111e-05,
+   2.946593876840e-08,    2.424901931663e-10,    3.640021236702e-05,    1.404810933253e-04,
+   6.027315517843e-06,    3.120239341189e-09,    2.555846760896e-11,    1.605383214264e-07,
+   1.283261801410e-06,    1.249753154813e-07,    1.417212716799e-10,    3.172177844467e-14,
+   1.243055968361e-08,    1.179347463416e-07,    1.243009710500e-08,    1.455408742395e-11,
+   1.896979840284e-16,    1.008932354567e-02,    3.891881654039e-02,    1.669717720522e-03,
+   1.942550594658e-05,    1.963758436941e-06,    9.572495448696e-02,    3.692525691742e-01,
+   1.584195857165e-02,    1.843042069766e-04,    1.863162129792e-05,    1.019004492191e-02,
+   3.987443435123e-02,    1.770439096762e-03,    1.954343855340e-05,    1.963759970926e-06,
+   9.674312087184e-04,    9.112218736980e-03,    9.575728638427e-04,    1.141658366052e-06,
+   2.313878774096e-09,    1.007215314341e-04,    9.556184181258e-04,    1.007214032037e-04,
+   1.179329044636e-07,    1.563892544574e-12,    3.107730453838e-02,    1.198803523848e-01,
+   6.814205514886e-03,    1.591491086640e-02,    1.677161527663e-03,    2.948638706112e-01,
+   1.137493824344e+00,    6.466199650490e-02,    1.509964825881e-01,    1.591246552953e-02,
+   4.014395388814e-02,    2.059023263362e-01,    1.588085486465e-02,    1.592552682135e-02,
+   1.677161665748e-03,    8.605836304392e-02,    8.162941428631e-01,    8.602995387573e-02,
+   1.193558225739e-04,    1.965064366456e-06,    9.066649961151e-03,    8.602197708730e-02,
+   9.066649591625e-03,    1.061619749794e-05,    1.636280241472e-10,    1.063407258334e-03,
+   4.120645731916e-03,    1.608824551940e-02,    1.509733519628e-01,    1.591246540711e-02,
+   1.009994179854e-02,    3.919630712741e-02,    1.526516382035e-01,    1.432395294182e+00,
+   1.509732682880e-01,    1.013005660809e-02,    9.014261968333e-02,    2.515489486916e-02,
+   1.509839679178e-01,    1.591246554520e-02,    8.602322038325e-02,    8.161586021817e-01,
+   8.604081266017e-02,    2.774929988696e-04,    1.863289157467e-05,    9.066649504040e-03,
+   8.602197532428e-02,    9.066649732868e-03,    1.061825443527e-05,    3.804314138910e-10,
+   4.042588254089e-07,    3.523062658579e-06,    1.677228335323e-03,    1.591246543848e-02,
+   1.677161514730e-03,    3.953418999570e-06,    3.454466319167e-05,    1.591321730085e-02,
+   1.509732687235e-01,    1.591246540667e-02,    1.011256350653e-04,    9.591408734976e-04,
+   1.777949711563e-03,    1.591258337109e-02,    1.677161516264e-03,    9.556182987297e-04,
+   9.066653612910e-03,    9.575816578685e-04,    1.975049493547e-05,    1.963768792413e-06,
+   1.007213777801e-04,    9.556178254467e-04,    1.007214033181e-04,    1.181749551398e-07,
+   2.707712044131e-11};
+
+double uref_general_1d[] = {
+   2.641215290314e-02,    1.735637235532e+00,    2.482858325164e+00,    8.768967029247e-01,
+   2.641215290314e-02};
+
+double uref_general_2d[] = {
+   1.591246589136e-02,    1.509919021644e-01,    3.182493105568e-02,    1.509918998654e-01,
+   1.591246564901e-02,    1.509919021644e-01,    1.163814190849e+00,    3.709492941403e-01,
+   1.298355206153e+00,    1.509732705833e-01,    3.182493105568e-02,    3.016976865743e-01,
+   5.487805097361e-02,    3.777759014638e-02,    1.591246589136e-02,    1.509918998654e-01,
+   1.226521011200e+00,    7.309228684390e-02,    2.055930438244e-03,    1.863388106479e-05,
+   1.591246564901e-02,    1.509732705833e-01,    1.591246589136e-02,    1.863388106479e-05,
+   4.846930553549e-10};
+
+double uref_general_3d[] = {
+   3.638778236171e-05,    1.403631607185e-04,    6.014885512534e-06,    3.105685301287e-09,
+   2.555827830023e-11,    3.452376812711e-04,    1.331728728121e-03,    5.706765938111e-05,
+   2.946593876840e-08,    2.424901931663e-10,    3.640021236702e-05,    1.404810933253e-04,
+   6.027315517843e-06,    3.120239341189e-09,    2.555846760896e-11,    1.605383214264e-07,
+   1.283261801410e-06,    1.249753154813e-07,    1.417212716799e-10,    3.172177844467e-14,
+   1.243055968361e-08,    1.179347463416e-07,    1.243009710500e-08,    1.455408742395e-11,
+   1.896979840284e-16,    1.008932354567e-02,    3.891881654039e-02,    1.669717720522e-03,
+   1.942550594658e-05,    1.963758436941e-06,    9.572495448696e-02,    6.209123679078e-01,
+   1.835262038094e-02,    5.559040069195e-05,    1.863162129792e-05,    1.019004492191e-02,
+   2.091827790048e-02,    2.493731399295e-03,    1.640146841364e-06,    1.963759970926e-06,
+   9.674312087184e-04,    2.406338913371e-02,    4.389149115333e-04,    1.072512138401e-05,
+   2.313878774096e-09,    1.007215314341e-04,    9.556184181258e-04,    1.007214032037e-04,
+   1.179329044636e-07,    1.563892544574e-12,    3.107730453838e-02,    1.198803523848e-01,
+   6.814205514886e-03,    1.591491086640e-02,    1.677161527663e-03,    2.948638706112e-01,
+   1.030789024577e+00,    1.380649120191e-01,    3.463038421383e-02,    1.591246552953e-02,
+   4.014395388814e-02,    1.962219874283e-01,    8.043619339473e-02,    2.877116849638e-02,
+   1.677161665748e-03,    8.605836304392e-02,    7.758560924391e-01,    2.415306615669e-02,
+   1.903497547298e-04,    1.965064366456e-06,    9.066649961151e-03,    8.602197708730e-02,
+   9.066649591625e-03,    1.061619749794e-05,    1.636280241472e-10,    1.063407258334e-03,
+   4.120645731916e-03,    1.608824551940e-02,    1.509733519628e-01,    1.591246540711e-02,
+   1.009994179854e-02,    1.418607516393e-02,    2.076581535410e-01,    1.160740477343e+00,
+   1.509732682880e-01,    1.013005660809e-02,    7.771554535358e-02,    5.946616678222e-02,
+   9.776832847948e-02,    1.591246554520e-02,    8.602322038325e-02,    3.576249042383e-01,
+   7.857560704118e-02,    1.718099963295e-04,    1.863289157467e-05,    9.066649504040e-03,
+   8.602197532428e-02,    9.066649732868e-03,    1.061825443527e-05,    3.804314138910e-10,
+   4.042588254089e-07,    3.523062658579e-06,    1.677228335323e-03,    1.591246543848e-02,
+   1.677161514730e-03,    3.953418999570e-06,    3.454466319167e-05,    1.591321730085e-02,
+   1.509732687235e-01,    1.591246540667e-02,    1.011256350653e-04,    9.591408734976e-04,
+   1.777949711563e-03,    1.591258337109e-02,    1.677161516264e-03,    9.556182987297e-04,
+   9.066653612910e-03,    9.575816578685e-04,    1.975049493547e-05,    1.963768792413e-06,
+   1.007213777801e-04,    9.556178254467e-04,    1.007214033181e-04,    1.181749551398e-07,
+   2.707712044131e-11};
+
+
+template <int dim>
+class TestFunction : public dealii::Function<dim>
+{
+private:
+  static const unsigned int n_source_centers = 3;
+  static const dealii::Point<dim>   source_centers[n_source_centers];
+  static const double       width;
+
+public:
+  TestFunction () : dealii::Function<dim>() {}
+
+  virtual double value (const dealii::Point<dim>   &p,
+                        const unsigned int  component = 0) const;
+};
+
+template <>
+const dealii::Point<1>
+TestFunction<1>::source_centers[TestFunction<1>::n_source_centers]
+= { dealii::Point<1>(-1.0 / 3.0),
+    dealii::Point<1>(0.0),
+    dealii::Point<1>(+1.0 / 3.0)   };
+
+template <>
+const dealii::Point<2>
+TestFunction<2>::source_centers[TestFunction<2>::n_source_centers]
+= { dealii::Point<2>(-0.5, +0.5),
+    dealii::Point<2>(-0.5, -0.5),
+    dealii::Point<2>(+0.5, -0.5)   };
+
+template <>
+const dealii::Point<3>
+TestFunction<3>::source_centers[TestFunction<3>::n_source_centers]
+= { dealii::Point<3>(-0.5, +0.5, 0.25),
+    dealii::Point<3>(-0.6, -0.5, -0.125),
+    dealii::Point<3>(+0.5, -0.5, 0.5)   };
+
+template <int dim>
+const double
+TestFunction<dim>::width = 1./3.;
+
+template <int dim>
+double TestFunction<dim>::value (const dealii::Point<dim>   &p,
+                             const unsigned int) const
+{
+  const double pi = dealii::numbers::PI;
+  double return_value = 0;
+  for (unsigned int i=0; i<this->n_source_centers; ++i)
+  {
+    const dealii::Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+    return_value += std::exp(-x_minus_xi.norm_square() /
+                             (this->width * this->width));
+  }
+
+  const double scale = std::sqrt(2 * pi) * this->width;
+  return return_value /(scale*scale);
+}
+
+
+template <int dim, typename Geometry>
+bool evaluate_and_compare(const Geometry& geometry, const double *uref)
+{
+  const unsigned int ntot = geometry.get_n_nodes_total();
+  dealii::Vector<double> u(ntot);
+
+  constexpr auto lambda = [] (const dealii::Point<dim> &p) {
+    const double radius = 0.6;
+    dealii::Point<dim> center;
+    center[0] = 0.2;
+
+    const double dist = (p-center).norm();
+
+    const double res = dist < radius? (1+cos(dealii::numbers::PI*dist/radius))/2 : 0.0;
+    return res;
+  };
+
+  // dealii::ScalarFunctionFromFunctionObject<dim> f(lambda);
+  TestFunction<dim> f;
+
+  geometry.initialize_vector(u,f);
+
+  double diff = 0.0;
+  for(int i = 0; i < ntot; ++i) {
+    double a = u[i] - uref[i];
+    diff += a*a;
+  }
+  std::cout << "  Difference: "<< diff/ntot << std::endl << std::endl;
+
+  return diff/ntot < 1e-24;
+}
+
+template <int dim>
+bool test_cartesian_geometry( const double *uref)
+{
+  unsigned int n = 5;
+
+  double xmin = -1.0;
+  double xmax = 1.0;
+
+  std::array<unsigned int,dim> n_nodes = stenseal::internal::repeat_value<dim>(n);
+  dealii::Point<dim> lower_left = stenseal::internal::repeat_point<dim>(xmin);
+  dealii::Point<dim> upper_right = stenseal::internal::repeat_point<dim>(xmax);
+
+  typedef stenseal::CartesianGeometry<dim> Geometry;
+  Geometry geometry(n_nodes,lower_left,upper_right);
+
+  return evaluate_and_compare<dim>(geometry,uref);
+}
+
+template <int dim>
+bool test_general_geometry(const double *uref)
+{
+  unsigned int n = 5;
+
+  double xmin = -1.0;
+  double xmax = 1.0;
+
+  std::array<unsigned int,dim> n_nodes = stenseal::internal::repeat_value<dim>(n);
+  dealii::Point<dim> lower_left = stenseal::internal::repeat_point<dim>(xmin);
+
+
+  double h[dim];
+  unsigned int n_nodes_tot = 1;
+  for(int i = 0; i < dim; ++i) {
+    h[i] = (xmax-xmin)/(n_nodes[i]-1);
+    n_nodes_tot *= n_nodes[i];
+  }
+
+  std::vector<dealii::Point<dim>> nodes(n_nodes_tot);
+
+  if(dim==1) {
+    for(int i = 0; i < n_nodes[0]; ++i) {
+      double x = lower_left(0)+h[0]*i;
+      nodes[i](0) = x;
+    }
+  }
+  else if(dim==2) {
+    for(int j = 0; j < n_nodes[1]; ++j) {
+      for(int i = 0; i < n_nodes[0]; ++i) {
+        double x = lower_left(0)+h[0]*i;
+        double y = lower_left(1)+h[1]*j;
+        const unsigned int idx = j*n_nodes[0] + i;
+        nodes[idx](0) = x;
+        nodes[idx](1) = y;
+      }
+    }
+  }
+  else if(dim==3) {
+    for(int k = 0; k < n_nodes[2]; ++k) {
+      for(int j = 0; j < n_nodes[1]; ++j) {
+        for(int i = 0; i < n_nodes[0]; ++i) {
+          double x = lower_left(0)+h[0]*i;
+          double y = lower_left(1)+h[1]*j;
+          double z = lower_left(2)+h[2]*k;
+          const unsigned int idx = (k*n_nodes[1]+j)*n_nodes[0] + i;
+          nodes[idx](0) = x;
+          nodes[idx](1) = y;
+          nodes[idx](2) = z;
+        }
+      }
+    }
+  }
+
+
+  if(dim==1) {
+    for(int i = 1; i < n_nodes[0]-1; ++i) {
+      nodes[i](0) += 0.3*h[0]*(2.0*(double)rand()/RAND_MAX - 1.0);
+    }
+  }
+  else if(dim==2) {
+    for(int j = 1; j < n_nodes[1]-1; ++j) {
+      for(int i = 1; i < n_nodes[0]-1; ++i) {
+        const unsigned int idx = j*n_nodes[0] + i;
+        nodes[idx](0) += 0.3*h[0]*(2.0*(double)rand()/RAND_MAX - 1.0);
+        nodes[idx](1) += 0.3*h[1]*(2.0*(double)rand()/RAND_MAX - 1.0);
+      }
+    }
+  }
+  else if(dim==3) {
+    for(int k = 1; k < n_nodes[2]-1; ++k) {
+      for(int j = 1; j < n_nodes[1]-1; ++j) {
+        for(int i = 1; i < n_nodes[0]-1; ++i) {
+          const unsigned int idx = (k*n_nodes[1]+j)*n_nodes[0] + i;
+          nodes[idx](0) += 0.3*h[0]*(2.0*(double)rand()/RAND_MAX - 1.0);
+          nodes[idx](1) += 0.3*h[1]*(2.0*(double)rand()/RAND_MAX - 1.0);
+          nodes[idx](2) += 0.3*h[2]*(2.0*(double)rand()/RAND_MAX - 1.0);
+        }
+      }
+    }
+  }
+
+
+  typedef stenseal::GeneralGeometry<dim> Geometry;
+  Geometry geometry(n_nodes,nodes);
+
+  return evaluate_and_compare<dim>(geometry,uref);
+}
+
+int main(int argc, char *argv[])
+{
+  srand(0);
+  bool allpass=true;
+
+  std::cout << "Tesing CartesianGeometry<1>" << std::endl;
+  allpass = test_cartesian_geometry<1>(uref_cartesian_1d) && allpass;
+  std::cout << "Tesing CartesianGeometry<2>" << std::endl;
+  allpass = test_cartesian_geometry<2>(uref_cartesian_2d) && allpass;
+  std::cout << "Tesing CartesianGeometry<3>" << std::endl;
+  allpass = test_cartesian_geometry<3>(uref_cartesian_3d) && allpass;
+
+  std::cout << "Tesing GeneralGeometry<1>" << std::endl;
+  allpass = test_general_geometry<1>(uref_general_1d) && allpass;
+  std::cout << "Tesing GeneralGeometry<2>" << std::endl;
+  allpass = test_general_geometry<2>(uref_general_2d) && allpass;
+  std::cout << "Tesing GeneralGeometry<3>" << std::endl;
+  allpass = test_general_geometry<3>(uref_general_3d) && allpass;
+
+  return allpass ? 0 : 1;
+}


### PR DESCRIPTION
Här händer det en hel del grejer, men förutom det som händer i `geometry.h` / `geometry.cc` ska det gå rätt bra att förstå. Sammafattningsvis:

- Ny geometri `GeneralGeometry`.
- `MetricCoefficient` har extraherats till egen fil.
- Initialisering av vektor från funktion bor nu i `*Geometry`. Test för detta.
- Test för Upwind Laplace på allmän geometri, dvs 1D-intervall med slumpskiftade punkter.

Det sista testet funkar inte! Som det är nu initialiseras coefficienten `c` till `Dm*xpos / h`. Detta används sedan i `UpwindLaplace` mellan `Dm` och `Dp`. Av nån anledning blir resultatet skräp. Bifogar en bild. @Werpers @ylvarydin Gör jag fel, eller har jag använt en för stygg geometri?