### PR TITLE
Metric coefficient improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,11 @@ ADD_EXECUTABLE(test_1d_general_upwind_laplace tests/test_1d_general_upwind_lapla
 TARGET_LINK_LIBRARIES(test_1d_general_upwind_laplace ${LIBNAME})
 STENSEAL_ADD_TEST(test_1d_general_upwind_laplace)
 
+# test for compact laplace in 1D for general geometry
+ADD_EXECUTABLE(test_1d_general_compact_laplace tests/test_1d_general_compact_laplace.cc)
+TARGET_LINK_LIBRARIES(test_1d_general_compact_laplace ${LIBNAME})
+STENSEAL_ADD_TEST(test_1d_general_compact_laplace)
+
 # test for coefficient matrix upwind laplance
 ADD_EXECUTABLE(test_1d_upwind_laplace_matrix tests/test_1d_upwind_laplace_matrix.cc)
 TARGET_LINK_LIBRARIES(test_1d_upwind_laplace_matrix ${LIBNAME})

--- a/include/stenseal/compact_laplace.h
+++ b/include/stenseal/compact_laplace.h
@@ -64,11 +64,17 @@ namespace stenseal
     if(dim == 1) {
       const unsigned int n = geometry.get_n_nodes(0);
 
-      D2.apply(dst,src,coeff,n);
+      const auto &inv_jac = coeff.inverse_jacobian();
 
-      // divide by h^2
+      D2.apply(dst,src,inv_jac,n);
+
+      // divide by h^2, and multiply by inverse jacobian
       const double h2 = geometry.get_mapped_h(0)*geometry.get_mapped_h(0);
-      dst /= h2;
+
+
+      for(int i = 0; i < n; ++i) {
+        dst[i] *= inv_jac.get(i)/h2;
+      }
     }
     else {
       AssertThrow(false,dealii::ExcNotImplemented());

--- a/include/stenseal/compact_laplace.h
+++ b/include/stenseal/compact_laplace.h
@@ -7,7 +7,7 @@
 
 #include <deal.II/lac/vector.h>
 
-#include "stenseal/metric_coefficient.h"
+#include "stenseal/metric.h"
 
 namespace stenseal
 {
@@ -28,7 +28,7 @@ namespace stenseal
     const D2Operator D2;
     const D1Operator D1;
     const Geometry geometry;
-    const MetricCoefficient<dim,Geometry> coeff;
+    const Metric<dim,Geometry> metric;
   public:
     /**
    * Constructor. Takes the 1D compact second-derivative SBP operator `d2`, the
@@ -53,7 +53,7 @@ namespace stenseal
   template <int dim, typename D2Operator, typename D1Operator, typename Geometry>
   CompactLaplace<dim,D2Operator,D1Operator,Geometry>
   ::CompactLaplace(const D2Operator d2, const D1Operator d1, const Geometry geom)
-    : D2(d2), D1(d1), geometry(geom), coeff(geom,d1)
+    : D2(d2), D1(d1), geometry(geom), metric(geom,d1)
   {}
 
 
@@ -64,7 +64,7 @@ namespace stenseal
     if(dim == 1) {
       const unsigned int n = geometry.get_n_nodes(0);
 
-      const auto &inv_jac = coeff.inverse_jacobian();
+      const auto &inv_jac = metric.inverse_jacobian();
 
       D2.apply(dst,src,inv_jac,n);
 

--- a/include/stenseal/metric.h
+++ b/include/stenseal/metric.h
@@ -2,8 +2,8 @@
  *
  */
 
-#ifndef _METRIC_COEFFICIENT_H
-#define _METRIC_COEFFICIENT_H
+#ifndef _METRIC_H
+#define _METRIC_H
 
 #include <array>
 
@@ -12,11 +12,11 @@
 
 namespace stenseal
 {
-  // metric coefficients
+  // metrics
 
   // forward declaration
   template <int dim, typename Geometry>
-  struct MetricCoefficient;
+  struct Metric;
 
 
   //---------------------------------------------------------------------------
@@ -72,18 +72,18 @@ namespace stenseal
 
 
   /**
-   * MetricCoefficient for cartesian geometry
+   * Metric for cartesian geometry
    */
 
   template <int dim>
-  struct MetricCoefficient<dim,CartesianGeometry<dim>>
+  struct Metric<dim,CartesianGeometry<dim>>
   {
   private:
     OneCoefficient coeff;
 
   public:
     template <typename dummy>
-      constexpr MetricCoefficient(const CartesianGeometry<dim>&, const dummy&);
+      constexpr Metric(const CartesianGeometry<dim>&, const dummy&);
 
     constexpr const OneCoefficient& inverse_jacobian() const;
 
@@ -91,11 +91,11 @@ namespace stenseal
 
 
   /**
-   * MetricCoefficient for general geometry
+   * Metric for general geometry
    */
 
   template <int dim>
-  struct MetricCoefficient<dim,GeneralGeometry<dim>>
+  struct Metric<dim,GeneralGeometry<dim>>
   {
   private:
     VectorCoefficient coeff;
@@ -103,7 +103,7 @@ namespace stenseal
 
   public:
     template <typename DmOp>
-    MetricCoefficient(const GeneralGeometry<dim> &g, const DmOp &op);
+    Metric(const GeneralGeometry<dim> &g, const DmOp &op);
 
     const VectorCoefficient& inverse_jacobian() const;
 
@@ -191,13 +191,13 @@ namespace stenseal
   // for cartesian geometry
   template <int dim>
   template <typename dummy>
-  constexpr MetricCoefficient<dim,CartesianGeometry<dim>>
-    ::MetricCoefficient(const CartesianGeometry<dim>&,
+  constexpr Metric<dim,CartesianGeometry<dim>>
+    ::Metric(const CartesianGeometry<dim>&,
                         const dummy&)
   {}
 
   template <int dim>
-  constexpr const OneCoefficient& MetricCoefficient<dim,CartesianGeometry<dim>>::inverse_jacobian() const
+  constexpr const OneCoefficient& Metric<dim,CartesianGeometry<dim>>::inverse_jacobian() const
   {
     return coeff;
   }
@@ -206,7 +206,7 @@ namespace stenseal
   // for general geometry
   template <int dim>
   template <typename DmOp>
-  MetricCoefficient<dim,GeneralGeometry<dim>>::MetricCoefficient(const GeneralGeometry<dim> &g, const DmOp &op)
+  Metric<dim,GeneralGeometry<dim>>::Metric(const GeneralGeometry<dim> &g, const DmOp &op)
   {
     const std::vector<dealii::Point<dim>> &pts = g.get_node_points();
     n_points = pts.size();
@@ -233,11 +233,11 @@ namespace stenseal
   }
 
   template <int dim>
-  const VectorCoefficient& MetricCoefficient<dim,GeneralGeometry<dim>>::inverse_jacobian() const
+  const VectorCoefficient& Metric<dim,GeneralGeometry<dim>>::inverse_jacobian() const
   {
     return coeff;
   }
 
 }
 
-#endif /* _METRIC_COEFFICIENT_H */
+#endif /* _METRIC_H */

--- a/include/stenseal/metric_operator.h
+++ b/include/stenseal/metric_operator.h
@@ -71,10 +71,11 @@ namespace stenseal
     }
 
     for(int i = n-height_boundary; i < n; ++i) {
-      const auto b = boundary[i-n+height_boundary].apply_inner_flip(coeff.template get_right_boundary_array<width_boundary>());
+      const auto b = boundary[n-1-i].apply_inner_flip(coeff.template get_right_boundary_array<width_boundary>());
+
       // FIXME: temporary fix to apply generated stencil in a non-centered fashion
-      dst[i] = b.apply_flip(src,n-width_boundary+(width_boundary-1)/2);
-      // dst[i] = b.apply_flip(src,i);
+      dst[i] = b.apply(src,n-width_boundary+(width_boundary-1)/2);
+      // dst[i] = b.apply(src,i);
     }
 
   }

--- a/include/stenseal/stencil.h
+++ b/include/stenseal/stencil.h
@@ -7,9 +7,10 @@
 #define _STENCIL_H
 
 #include <array>
-#include <utility>
 
 #include <deal.II/lac/vector.h>
+
+#include "stenseal/utils.h"
 
 namespace stenseal
 {
@@ -90,13 +91,6 @@ namespace stenseal
   // Implementations
   //=============================================================================
 
-  namespace internal
-  {
-    template <int m>
-    struct gen_offsets;
-  }
-
-
   template <int width>
   constexpr  Stencil<width>::Stencil(const std::array<double,width> w, const std::array<int,width> o)
     : weights(w), offsets(o)
@@ -161,65 +155,6 @@ namespace stenseal
   {
     return offsets;
   }
-
-  //=============================================================================
-  // append/prepend to std::array
-  //=============================================================================
-
-  template <typename T, std::size_t N, std::size_t... I>
-  constexpr std::array<T, N + 1> append_aux(const std::array<T, N> a, T t,
-                                            const std::index_sequence<I...>)
-  {
-    return std::array<T, N + 1>{ a[I]..., t };
-  }
-
-  template <typename T, std::size_t N>
-  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t)
-  {
-    return append_aux(a, t, std::make_index_sequence<N>());
-  }
-
-  template <typename T, std::size_t N, std::size_t... I>
-  constexpr std::array<T, N + 1> prepend_aux(T t,const std::array<T, N> a,
-                                             const std::index_sequence<I...>)
-  {
-    return std::array<T, N + 1>{t, a[I]... };
-  }
-
-  template <typename T, std::size_t N>
-  constexpr std::array<T, N+1> prepend(const T t, const std::array<T, N> a)
-  {
-    return prepend_aux(t,a, std::make_index_sequence<N>());
-  }
-
-  namespace internal
-  {
-    // generate contiguous list of offsets centered around 0
-    template <>
-    struct gen_offsets<1>
-    {
-      static constexpr std::array<int,1> value{0};
-    };
-
-    template <>
-    struct gen_offsets<2>
-    {
-      static constexpr std::array<int,2> value{0,1};
-    };
-
-    template <int m>
-    struct gen_offsets
-    {
-      static constexpr std::array<int,m> value = prepend((m%2==0)-m/2, append(gen_offsets<m-2>::value, m/2));
-    };
-
-    template <int m>
-    constexpr std::array<int,m> gen_offsets<m>::value;
-
-    constexpr std::array<int,1> gen_offsets<1>::value;
-    constexpr std::array<int,2> gen_offsets<2>::value;
-  }
-
 
   //=============================================================================
   // infrastructure for expression template

--- a/include/stenseal/upwind_laplace.h
+++ b/include/stenseal/upwind_laplace.h
@@ -73,6 +73,8 @@ namespace stenseal
 
     if(dim==1) {
 
+      const auto &inv_jac = coeff.inverse_jacobian();
+
       const unsigned int n = geometry.get_n_nodes(0);
 
       // for now, use full temporary array
@@ -88,7 +90,7 @@ namespace stenseal
       // stupid inefficient way of multiplying with c and 1/h^2
       // FIXME: merge with above.
       for(int i = 0; i<n; ++i) {
-        tmp[i] /= coeff.get(i);
+        tmp[i] *= inv_jac.get(i);
       }
 
       //-------------------------------------------------------------------------
@@ -99,7 +101,7 @@ namespace stenseal
       const double h2 = geometry.get_mapped_h(0)*geometry.get_mapped_h(0);
 
       for(int i = 0; i<n; ++i) {
-        dst[i] /= coeff.get(i)*h2;
+        dst[i] *= inv_jac.get(i)/h2;
       }
 
     }

--- a/include/stenseal/upwind_laplace.h
+++ b/include/stenseal/upwind_laplace.h
@@ -10,8 +10,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 
-#include "stenseal/geometry.h"
-#include "stenseal/metric_coefficient.h"
+#include "stenseal/metric.h"
 
 namespace stenseal
 {
@@ -27,7 +26,7 @@ namespace stenseal
   private:
     const DmT Dm;
     const Geometry geometry;
-    const MetricCoefficient<dim,Geometry> coeff;
+    const Metric<dim,Geometry> metric;
 
   public:
     /**
@@ -55,7 +54,7 @@ namespace stenseal
   template <int dim, typename DmT, typename Geometry>
   UpwindLaplace<dim,DmT,Geometry>
   ::UpwindLaplace(const DmT dm, const Geometry &g)
-    : Dm(dm), geometry(g), coeff(g,dm)
+    : Dm(dm), geometry(g), metric(g,dm)
   {}
 
 
@@ -73,7 +72,7 @@ namespace stenseal
 
     if(dim==1) {
 
-      const auto &inv_jac = coeff.inverse_jacobian();
+      const auto &inv_jac = metric.inverse_jacobian();
 
       const unsigned int n = geometry.get_n_nodes(0);
 

--- a/include/stenseal/utils.h
+++ b/include/stenseal/utils.h
@@ -1,0 +1,98 @@
+/* -*- c-basic-offset:2; tab-width:2; indent-tabs-mode:nil -*-
+ *
+ */
+
+#ifndef _UTILS_H
+#define _UTILS_H
+
+#include <array>
+#include <utility>
+
+namespace stenseal
+{
+  namespace internal
+  {
+    template <std::size_t n, typename T>
+    constexpr std::array<T,n> repeat_value(const T val);
+
+    template <int m>
+    struct gen_offsets;
+  }
+
+
+  //=============================================================================
+  // append/prepend to std::array
+  //=============================================================================
+
+  template <typename T, std::size_t N, std::size_t... I>
+  constexpr std::array<T, N + 1> append_aux(const std::array<T, N> a, T t,
+                                            const std::index_sequence<I...>)
+  {
+    return std::array<T, N + 1>{ a[I]..., t };
+  }
+
+  template <typename T, std::size_t N>
+  constexpr std::array<T, N+1> append(const std::array<T, N> a, const T t)
+  {
+    return append_aux(a, t, std::make_index_sequence<N>());
+  }
+
+  template <typename T, std::size_t N, std::size_t... I>
+  constexpr std::array<T, N + 1> prepend_aux(T t,const std::array<T, N> a,
+                                             const std::index_sequence<I...>)
+  {
+    return std::array<T, N + 1>{t, a[I]... };
+  }
+
+  template <typename T, std::size_t N>
+  constexpr std::array<T, N+1> prepend(const T t, const std::array<T, N> a)
+  {
+    return prepend_aux(t,a, std::make_index_sequence<N>());
+  }
+
+  namespace internal
+  {
+
+    template <std::size_t n, typename T, std::size_t... I>
+    constexpr std::array<T,n> repeat_value_impl(const T val, const std::index_sequence<I...>)
+    {
+      return { (I,val)...};
+    }
+
+    template <std::size_t n, typename T>
+    constexpr std::array<T,n> repeat_value(const T val)
+    {
+      return repeat_value_impl<n>(val,std::make_index_sequence<n>());
+    }
+
+    // generate contiguous list of offsets centered around 0
+    template <>
+    struct gen_offsets<1>
+    {
+      static constexpr std::array<int,1> value{0};
+    };
+
+    template <>
+    struct gen_offsets<2>
+    {
+      static constexpr std::array<int,2> value{0,1};
+    };
+
+    template <int m>
+    struct gen_offsets
+    {
+      static constexpr std::array<int,m> value = prepend((m%2==0)-m/2, append(gen_offsets<m-2>::value, m/2));
+    };
+
+    template <int m>
+    constexpr std::array<int,m> gen_offsets<m>::value;
+
+    constexpr std::array<int,1> gen_offsets<1>::value;
+    constexpr std::array<int,2> gen_offsets<2>::value;
+  }
+
+
+
+}
+
+#endif /* _UTILS_H */

--- a/tests/test_1d_general_compact_laplace.cc
+++ b/tests/test_1d_general_compact_laplace.cc
@@ -1,0 +1,191 @@
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/base/numbers.h>
+
+#include "stenseal/geometry.h"
+#include "stenseal/operator.h"
+#include "stenseal/compact_laplace.h"
+#include "stenseal/metric_operator.h"
+#include "stenseal/operator_lib.h"
+
+#include <fstream>
+
+template <typename OperatorTypeD2, typename OperatorTypeD1>
+void compute_l2_norm(std::pair<OperatorTypeD2,OperatorTypeD1> ops, unsigned int n,
+                     double &l2_norm, double &l2_norm_interior)
+{
+  const int dim = 1;
+
+  std::array<unsigned int,dim> n_nodes{ n };
+  int n_nodes_tot = n_nodes[0];
+  double h = 1.0/(n_nodes_tot-1);
+  const double PI = dealii::numbers::PI;
+
+  // node positions
+  std::vector<dealii::Point<dim>> nodes(n_nodes_tot);
+
+  {
+    // use cartesian geometry to set up initial points
+    stenseal::CartesianGeometry<dim> g(n_nodes);
+
+    dealii::Vector<double> xpos(n_nodes_tot);
+    g.initialize_vector(xpos,[] (const dealii::Point<dim> &p)
+                               { const double x= p(0);
+                                 return (exp(x)-1)/(exp(1)-1);
+                                });
+
+    for(int i = 0; i < n_nodes[0]; ++i) {
+      nodes[i](0) = xpos[i];
+    }
+  }
+
+  // std::ofstream node_file("nodes.txt");
+  // for(auto p : nodes)
+  //   node_file << p << std::endl;
+
+  typedef stenseal::GeneralGeometry<dim> Geometry;
+  Geometry geometry(n_nodes,nodes);
+
+  stenseal::CompactLaplace<dim,OperatorTypeD2,OperatorTypeD1,Geometry> op(ops.first,ops.second,geometry);
+
+  dealii::Vector<double> u(n_nodes_tot);
+
+  auto test_function =
+    [=](const dealii::Point<dim> &p) { return sin(PI*p(0)); };
+  auto test_function_2nd_derivative =
+    [=](const dealii::Point<dim> &p) { return -PI*PI*sin(PI*p(0)); };
+
+  geometry.initialize_vector(u,test_function);
+
+  dealii::Vector<double> v(n_nodes_tot);
+
+  op.apply(v,u);
+
+
+  dealii::Vector<double> vref(n_nodes_tot);
+  geometry.initialize_vector(vref,test_function_2nd_derivative);
+
+  // std::ofstream u_file("initial_condition.txt");
+  // u.print(u_file);
+
+  // std::ofstream v_file("2nd_derivative.txt");
+  // v.print(v_file);
+
+  // std::ofstream vref_file("ref_2nd_derivative.txt");
+  // vref.print(vref_file);
+
+  // exclude points affected by boundary stencil
+  const int height_bdry = 2;
+  const int bdry_offset = height_bdry;
+
+  // compute norms
+  double sqsum = 0;
+  double a;
+  for(int i = bdry_offset; i < n_nodes_tot-bdry_offset; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+  l2_norm_interior = std::sqrt(h*sqsum);
+
+  for(int i= 0; i < bdry_offset; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+
+  for(int i = n_nodes_tot-bdry_offset; i < n_nodes_tot; ++i) {
+    a = v[i] - vref[i];
+    sqsum += a*a;
+  }
+
+  l2_norm = std::sqrt(h*sqsum);
+}
+
+
+template <typename OperatorTypeD2, typename OperatorTypeD1>
+bool test_operator(std::pair<OperatorTypeD2,OperatorTypeD1> ops, float interior_p_ref, float full_p_ref)
+{
+  const int n_tests = 7;
+  double full_norms[n_tests];
+  double interior_norms[n_tests];
+  unsigned int size = 40;
+
+  for(int i=0; i<n_tests; i++) {
+    compute_l2_norm(ops,size,full_norms[i],interior_norms[i]);
+    size *= 2;
+  }
+
+  printf("     n   full error   factor  (p)   inter. error   factor   (p)\n");
+  printf(" ---------------------------------------------------------------\n");
+
+  size=40;
+  printf("%6d %12.4g       - ( - )   %12.4g        - ( - )\n",size,full_norms[0],interior_norms[0]);
+  size *= 2;
+
+  bool all_conv = true;
+  double tol = 1e-08;
+  for(int i=1; i<n_tests; i++) {
+    double full_conv = full_norms[i-1] / full_norms[i];
+    double full_p = std::log2(full_conv);
+    double interior_conv = interior_norms[i-1] / interior_norms[i];
+    double interior_p = std::log2(interior_conv);
+    printf("%6d %12.4g %7.3g (%.1f)   %12.4g %8.3g (%.1f)\n",size,full_norms[i],full_conv,full_p,
+           interior_norms[i],interior_conv,interior_p);
+
+    size *= 2;
+    all_conv = all_conv && (interior_p > interior_p_ref && full_p > full_p_ref);
+    if(interior_norms[i] < tol) break;
+  }
+  printf("\n");
+  return all_conv;
+}
+
+int main(int argc, char *argv[])
+{
+  bool all_conv = true;
+
+  printf("Second order Compact:\n");
+
+  const stenseal::Symbol sym;
+
+  constexpr stenseal::Stencil<2> d1_interior((-0.5)*sym[-1] + 0.5*sym[1]);
+
+  constexpr stenseal::StencilTensor2D<1,2> d1_boundary((-1.0)*sym[0] + 1.0*sym[1]);
+  constexpr stenseal::StencilTensor2D<1,2> d1_boundary_r((-1.0)*sym[-1] + 1.0*sym[0]);
+
+
+  constexpr stenseal::Operator<2,2,1,2,1> D1 (d1_interior,
+                                              d1_boundary,
+                                              d1_boundary_r);
+
+
+  constexpr stenseal::StencilTensor2D<3,3> d2_interior((0.5)*sym[-1]  + (0.5)*sym[0] + 0.0*sym[1],
+                                                       (-0.5)*sym[-1] + (-1.0)*sym[0]+ (-0.5)*sym[1],
+                                                       0.0*sym[-1]    + (0.5)*sym[0] + (0.5)*sym[1]);
+
+
+  constexpr stenseal::StencilTensor3D<2,3,3> d2_boundary( stenseal::StencilTensor2D<3,3>((2.0)*sym[0]   + (-1.0)*sym[1]  + (0.0)*sym[2],
+                                                                                         (-3.0)*sym[-1] + (1.0)*sym[0]   + (0.0)*sym[1],
+                                                                                         (1.0)*sym[-2]  + (0.0)*sym[-1]  + (0.0)*sym[0]),
+                                                          stenseal::StencilTensor2D<3,3>((0.5)*sym[0]   + (0.5)*sym[1]   + (0.0)*sym[2],
+                                                                                         (-0.5)*sym[-1] + (-1.0)*sym[0]  + (-0.5)*sym[1],
+                                                                                         (0.0)*sym[-2]  + (0.5)*sym[-1] + (0.5)*sym[0]));
+
+
+  constexpr stenseal::MetricOperator<3,3,2> D2 (d2_interior,
+                                                d2_boundary);
+
+
+  all_conv = test_operator(std::make_pair(D2,D1),1.9,1.4) && all_conv;
+
+
+  if(all_conv) {
+    printf("Proper convergence order attained\n");
+    return 0;
+  }
+  else {
+    printf("Proper convergence NOT attained\n");
+    return 1;
+  }
+}

--- a/tests/test_1d_general_upwind_laplace.cc
+++ b/tests/test_1d_general_upwind_laplace.cc
@@ -28,7 +28,7 @@ void compute_l2_norm(OperatorType Dm, unsigned int n, double &l2_norm, double &l
     dealii::Vector<double> xpos(n_nodes_tot);
     g.initialize_vector(xpos,[] (const dealii::Point<dim> &p)
                         { const double x= p(0);
-                          return x + 0.8*x*(2*x-1)*(1-x);
+                          return (exp(x)-1)/(exp(1)-1);
                         });
 
     for(int i = 0; i < n_nodes[0]; ++i) {

--- a/tests/test_initialize_vector.cc
+++ b/tests/test_initialize_vector.cc
@@ -4,8 +4,8 @@
 #include <deal.II/base/function.h>
 
 #include "stenseal/geometry.h"
-#include "stenseal/operator.h"
-#include "stenseal/metric_coefficient.h"
+
+#include "stenseal/utils.h"
 
 #include <fstream>
 


### PR DESCRIPTION
+ Correct boundary stencil application for `CompactLaplace` by flipping the right number of times.
+ Introduce classes for coefficients be able to swap a unit coefficient for a general one with the same interface (and with constexpr magic!)
+ Add test for compact laplace on transformed 1D domain. Seems okay, but the boundary stencil is fundamentally inaccurate (according to plan?! D: ).

Wait with merging until #18 is merged first! (Only the last 6 commits are part of this PR)