### PR TITLE
Missing declarations

### DIFF
--- a/examples/benchmarks_1d.cc
+++ b/examples/benchmarks_1d.cc
@@ -10,6 +10,9 @@
 #include "stenseal/compact_laplace.h"
 #include "stenseal/operator_lib.h"
 
+#ifdef __APPLE__
+  #include <fenv.h>
+#endif
 
 #define NREPS 1000
 

--- a/include/stenseal/asymmetric_sbp.h
+++ b/include/stenseal/asymmetric_sbp.h
@@ -164,6 +164,40 @@ namespace stenseal
     return rboundary;
   }
 
+  template <int width_interior,
+            int width_boundary_l,
+            int height_boundary_l,
+            int width_boundary_r,
+            int height_boundary_r>
+  const int AsymmetricSBP<width_interior,width_boundary_l,height_boundary_l,width_boundary_r,height_boundary_r>::height_r;
+
+  template <int width_interior,
+            int width_boundary_l,
+            int height_boundary_l,
+            int width_boundary_r,
+            int height_boundary_r>
+  const int AsymmetricSBP<width_interior,width_boundary_l,height_boundary_l,width_boundary_r,height_boundary_r>::height_l;
+
+  template <int width_interior,
+            int width_boundary_l,
+            int height_boundary_l,
+            int width_boundary_r,
+            int height_boundary_r>
+  const int AsymmetricSBP<width_interior,width_boundary_l,height_boundary_l,width_boundary_r,height_boundary_r>::width_r;
+
+  template <int width_interior,
+            int width_boundary_l,
+            int height_boundary_l,
+            int width_boundary_r,
+            int height_boundary_r>
+  const int AsymmetricSBP<width_interior,width_boundary_l,height_boundary_l,width_boundary_r,height_boundary_r>::width_l;
+
+  template <int width_interior,
+            int width_boundary_l,
+            int height_boundary_l,
+            int width_boundary_r,
+            int height_boundary_r>
+  const int AsymmetricSBP<width_interior,width_boundary_l,height_boundary_l,width_boundary_r,height_boundary_r>::width_i;
 
 }
 

--- a/include/stenseal/symmetric_sbp.h
+++ b/include/stenseal/symmetric_sbp.h
@@ -108,6 +108,21 @@ namespace stenseal
     return boundary;
   }
 
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int SymmetricSBP<width_interior,width_boundary,height_boundary>::height_b;
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int SymmetricSBP<width_interior,width_boundary,height_boundary>::width_b;
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int SymmetricSBP<width_interior,width_boundary,height_boundary>::width_i;
+
 }
 
 #endif /* _SYMMETRIC_SBP_H */

--- a/include/stenseal/variable_symmetric_sbp.h
+++ b/include/stenseal/variable_symmetric_sbp.h
@@ -106,6 +106,21 @@ namespace stenseal
     return interior;
   }
 
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int VariableSymmetricSBP<width_interior,width_boundary,height_boundary>::height_b;
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int VariableSymmetricSBP<width_interior,width_boundary,height_boundary>::width_b;
+
+  template <int width_interior,
+            int width_boundary,
+            int height_boundary>
+  const int VariableSymmetricSBP<width_interior,width_boundary,height_boundary>::width_i;
+
 }
 
 #endif /* _VARIABLE_SYMMETRIC_SBP_H */


### PR DESCRIPTION
Lägger till några deklarationer (eller vad det nu kan kallas) som saknas och gör kaos med clang.
Lägger också till en header som krävs för att det ska fungera att stänga av denorm floats